### PR TITLE
fix: テストの失敗を修正 - AccountDialogバリデーションと404ページ (#28)

### DIFF
--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -6,6 +6,7 @@ export default function NotFound() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50">
       <div className="text-center">
+        <h1 className="text-6xl font-bold text-gray-300 mb-4">404</h1>
         <h2 className="text-2xl font-bold text-gray-900 mb-4">ページが見つかりません</h2>
         <p className="text-gray-600 mb-8">
           お探しのページは存在しないか、移動した可能性があります。

--- a/apps/web/src/components/accounts/account-dialog.tsx
+++ b/apps/web/src/components/accounts/account-dialog.tsx
@@ -151,7 +151,7 @@ export function AccountDialog({
                     </FormControl>
                     <SelectContent>
                       {Object.entries(AccountTypeLabels).map(([value, label]) => (
-                        <SelectItem key={value} value={value}>
+                        <SelectItem key={value} value={value} data-testid={`select-item-${value}`}>
                           {label}
                         </SelectItem>
                       ))}
@@ -176,7 +176,11 @@ export function AccountDialog({
                     <SelectContent>
                       <SelectItem value="none">なし</SelectItem>
                       {filteredParentAccounts.map((acc) => (
-                        <SelectItem key={acc.id} value={acc.id}>
+                        <SelectItem
+                          key={acc.id}
+                          value={acc.id}
+                          data-testid={`select-item-${acc.id}`}
+                        >
                           {acc.code} - {acc.name}
                         </SelectItem>
                       ))}

--- a/apps/web/src/types/schemas.ts
+++ b/apps/web/src/types/schemas.ts
@@ -3,8 +3,14 @@ import { z } from 'zod';
 import { AccountType } from './account';
 
 export const createAccountSchema = z.object({
-  code: z.string().min(1, '勘定科目コードは必須です'),
-  name: z.string().min(1, '勘定科目名は必須です'),
+  code: z
+    .string()
+    .min(1, '勘定科目コードを入力してください')
+    .max(10, '勘定科目コードは10文字以内で入力してください'),
+  name: z
+    .string()
+    .min(1, '勘定科目名を入力してください')
+    .max(100, '勘定科目名は100文字以内で入力してください'),
   accountType: z.enum([
     AccountType.ASSET,
     AccountType.LIABILITY,


### PR DESCRIPTION
## 概要

Issue #28 で報告されたテストの失敗を修正しました。

## 変更内容

### 1. AccountDialog バリデーションテストの修正
- 勘定科目コードと名称の文字数制限バリデーションを追加
  - コード: 最大10文字
  - 名称: 最大100文字
- バリデーションエラーメッセージをテストが期待するテキストに修正
- SelectItemコンポーネントに`data-testid`属性を追加してテストの安定性を向上

### 2. 404ページ E2Eテストの修正
- 404ページに大きな「404」エラーコードを表示
- E2Eテストが期待する「404」テキストが確実に表示されるよう修正
- デザインも改善し、より分かりやすいエラーページに

### 3. ESLintエラーの修正
- `layout.tsx`と`journal-entry-line-items.tsx`のインポート順序を修正
- lint-stagedによる自動フォーマットも適用

## テスト計画

- [x] AccountDialogの単体テストが全て成功することを確認
- [x] 404ページのE2Eテストが成功することを確認
- [x] ESLintが通ることを確認
- [x] TypeScriptの型チェックが通ることを確認

## 関連Issue

Closes #28

🤖 Generated with [Claude Code](https://claude.ai/code)