### PR TITLE
fix: ページ再読み込み時にログイン状態が解除される問題を修正 (#23)

### DIFF
--- a/apps/api/src/routes/auth.routes.ts
+++ b/apps/api/src/routes/auth.routes.ts
@@ -41,4 +41,7 @@ router.post(
 // Logout
 router.post('/logout', authenticate, authController.logout);
 
+// Get current user
+router.get('/me', authenticate, authController.getMe);
+
 export default router;


### PR DESCRIPTION
## 概要

ページを再読み込みするとログイン状態が解除され、ログイン画面にリダイレクトされる問題を修正しました。

Fixes #23

## 変更内容

### 1. APIエンドポイントの追加
- `/auth/me` エンドポイントを新規追加
- JWTトークンから現在のユーザー情報と組織情報を返す実装

### 2. AuthContextの改善
- LocalStorageにユーザー情報をキャッシュする機能を追加
- ページリロード時の復元処理を2段階で実装：
  1. LocalStorageから即座に復元（高速）
  2. バックグラウンドで `/auth/me` を呼び出して最新情報を取得
- ログイン、ログアウト、組織切り替え時にLocalStorageを適切に更新

### 3. セキュリティ考慮事項
- LocalStorageには基本的なユーザー情報のみ保存（パスワード等の機密情報は含まない）
- トークンの有効性はAPIコールで検証
- 無効なトークンの場合は自動的にログアウト処理を実行

## テスト計画

- [x] ローカル環境でのテスト
  - [x] ログイン後のページリロードでログイン状態が維持されることを確認
  - [x] ログアウト後にLocalStorageがクリアされることを確認
  - [x] 組織切り替え後にLocalStorageが更新されることを確認
- [ ] 本番環境でのテスト（デプロイ後）

## 破壊的変更

なし

🤖 Generated with [Claude Code](https://claude.ai/code)