### PR TITLE
fix: 勘定科目検索でローマ字入力が正しく機能しない問題を修正 (#21)

### DIFF
--- a/apps/web/src/components/ui/__tests__/account-search-combobox.test.tsx
+++ b/apps/web/src/components/ui/__tests__/account-search-combobox.test.tsx
@@ -1,0 +1,308 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { AccountSearchCombobox } from '../account-search-combobox';
+
+// Mock scrollIntoView which is not available in jsdom
+beforeAll(() => {
+  Element.prototype.scrollIntoView = jest.fn();
+});
+
+describe('AccountSearchCombobox', () => {
+  const mockAccounts = [
+    {
+      id: '1',
+      code: '1110',
+      name: '現金',
+      nameKana: 'ゲンキン',
+      accountType: 'ASSET' as const,
+    },
+    {
+      id: '2',
+      code: '1120',
+      name: '小口現金',
+      nameKana: 'コグチゲンキン',
+      accountType: 'ASSET' as const,
+    },
+    {
+      id: '3',
+      code: '1210',
+      name: '普通預金',
+      nameKana: 'フツウヨキン',
+      accountType: 'ASSET' as const,
+    },
+    {
+      id: '4',
+      code: '4110',
+      name: '売上高',
+      nameKana: 'ウリアゲダカ',
+      accountType: 'REVENUE' as const,
+    },
+    {
+      id: '5',
+      code: '5680',
+      name: 'コンサルティング費',
+      nameKana: 'コンサルティングヒ',
+      accountType: 'EXPENSE' as const,
+    },
+  ];
+
+  const mockOnValueChange = jest.fn();
+
+  beforeEach(() => {
+    mockOnValueChange.mockClear();
+  });
+
+  it('renders with placeholder', () => {
+    render(
+      <AccountSearchCombobox
+        accounts={mockAccounts}
+        onValueChange={mockOnValueChange}
+        placeholder="Select account"
+      />
+    );
+    expect(screen.getByText('Select account')).toBeInTheDocument();
+  });
+
+  it('searches by account code', async () => {
+    render(<AccountSearchCombobox accounts={mockAccounts} onValueChange={mockOnValueChange} />);
+
+    const button = screen.getByRole('combobox');
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText('コード、名前、カナ、ローマ字で検索...')
+      ).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText('コード、名前、カナ、ローマ字で検索...');
+    fireEvent.change(searchInput, { target: { value: '1110' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('現金')).toBeInTheDocument();
+      expect(screen.queryByText('売上高')).not.toBeInTheDocument();
+    });
+  });
+
+  it('searches by account name in kanji', async () => {
+    render(<AccountSearchCombobox accounts={mockAccounts} onValueChange={mockOnValueChange} />);
+
+    const button = screen.getByRole('combobox');
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText('コード、名前、カナ、ローマ字で検索...')
+      ).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText('コード、名前、カナ、ローマ字で検索...');
+    fireEvent.change(searchInput, { target: { value: '現金' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('現金')).toBeInTheDocument();
+      expect(screen.getByText('小口現金')).toBeInTheDocument();
+      expect(screen.queryByText('売上高')).not.toBeInTheDocument();
+    });
+  });
+
+  it('searches by katakana', async () => {
+    render(<AccountSearchCombobox accounts={mockAccounts} onValueChange={mockOnValueChange} />);
+
+    const button = screen.getByRole('combobox');
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText('コード、名前、カナ、ローマ字で検索...')
+      ).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText('コード、名前、カナ、ローマ字で検索...');
+    fireEvent.change(searchInput, { target: { value: 'ゲンキン' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('現金')).toBeInTheDocument();
+      expect(screen.getByText('小口現金')).toBeInTheDocument();
+      expect(screen.queryByText('売上高')).not.toBeInTheDocument();
+    });
+  });
+
+  it('searches by hiragana', async () => {
+    render(<AccountSearchCombobox accounts={mockAccounts} onValueChange={mockOnValueChange} />);
+
+    const button = screen.getByRole('combobox');
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText('コード、名前、カナ、ローマ字で検索...')
+      ).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText('コード、名前、カナ、ローマ字で検索...');
+    fireEvent.change(searchInput, { target: { value: 'げんきん' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('現金')).toBeInTheDocument();
+      expect(screen.getByText('小口現金')).toBeInTheDocument();
+      expect(screen.queryByText('売上高')).not.toBeInTheDocument();
+    });
+  });
+
+  it('searches by romaji - genkin should find 現金', async () => {
+    render(<AccountSearchCombobox accounts={mockAccounts} onValueChange={mockOnValueChange} />);
+
+    const button = screen.getByRole('combobox');
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText('コード、名前、カナ、ローマ字で検索...')
+      ).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText('コード、名前、カナ、ローマ字で検索...');
+    fireEvent.change(searchInput, { target: { value: 'genkin' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('現金')).toBeInTheDocument();
+      expect(screen.getByText('小口現金')).toBeInTheDocument();
+      expect(screen.queryByText('売上高')).not.toBeInTheDocument();
+    });
+  });
+
+  it('searches by romaji - uriage should find 売上高', async () => {
+    render(<AccountSearchCombobox accounts={mockAccounts} onValueChange={mockOnValueChange} />);
+
+    const button = screen.getByRole('combobox');
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText('コード、名前、カナ、ローマ字で検索...')
+      ).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText('コード、名前、カナ、ローマ字で検索...');
+    fireEvent.change(searchInput, { target: { value: 'uriage' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('売上高')).toBeInTheDocument();
+      expect(screen.queryByText('現金')).not.toBeInTheDocument();
+    });
+  });
+
+  it('searches by romaji - con should find コンサルティング費', async () => {
+    render(<AccountSearchCombobox accounts={mockAccounts} onValueChange={mockOnValueChange} />);
+
+    const button = screen.getByRole('combobox');
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText('コード、名前、カナ、ローマ字で検索...')
+      ).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText('コード、名前、カナ、ローマ字で検索...');
+    fireEvent.change(searchInput, { target: { value: 'con' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('コンサルティング費')).toBeInTheDocument();
+      expect(screen.queryByText('現金')).not.toBeInTheDocument();
+    });
+  });
+
+  it('searches by partial romaji - gen should find 現金', async () => {
+    render(<AccountSearchCombobox accounts={mockAccounts} onValueChange={mockOnValueChange} />);
+
+    const button = screen.getByRole('combobox');
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText('コード、名前、カナ、ローマ字で検索...')
+      ).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText('コード、名前、カナ、ローマ字で検索...');
+    fireEvent.change(searchInput, { target: { value: 'gen' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('現金')).toBeInTheDocument();
+      expect(screen.getByText('小口現金')).toBeInTheDocument();
+      expect(screen.queryByText('売上高')).not.toBeInTheDocument();
+    });
+  });
+
+  it('selects an account', async () => {
+    render(<AccountSearchCombobox accounts={mockAccounts} onValueChange={mockOnValueChange} />);
+
+    const button = screen.getByRole('combobox');
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText('コード、名前、カナ、ローマ字で検索...')
+      ).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText('コード、名前、カナ、ローマ字で検索...');
+    fireEvent.change(searchInput, { target: { value: 'genkin' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('現金')).toBeInTheDocument();
+    });
+
+    const cashOption = screen.getByText('現金').closest('[role="option"]');
+    if (cashOption) {
+      fireEvent.click(cashOption);
+    }
+
+    await waitFor(() => {
+      expect(mockOnValueChange).toHaveBeenCalledWith('1');
+    });
+  });
+
+  it('shows "no results" message when no accounts match', async () => {
+    render(<AccountSearchCombobox accounts={mockAccounts} onValueChange={mockOnValueChange} />);
+
+    const button = screen.getByRole('combobox');
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText('コード、名前、カナ、ローマ字で検索...')
+      ).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText('コード、名前、カナ、ローマ字で検索...');
+    fireEvent.change(searchInput, { target: { value: 'xyz123' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('勘定科目が見つかりません')).toBeInTheDocument();
+    });
+  });
+
+  it('displays selected account', () => {
+    render(
+      <AccountSearchCombobox accounts={mockAccounts} value="1" onValueChange={mockOnValueChange} />
+    );
+
+    expect(screen.getByText('1110 - 現金')).toBeInTheDocument();
+  });
+
+  it('handles disabled state', () => {
+    render(
+      <AccountSearchCombobox
+        accounts={mockAccounts}
+        onValueChange={mockOnValueChange}
+        disabled={true}
+      />
+    );
+
+    const button = screen.getByRole('combobox');
+    expect(button).toBeDisabled();
+  });
+});

--- a/apps/web/src/components/ui/account-search-combobox.tsx
+++ b/apps/web/src/components/ui/account-search-combobox.tsx
@@ -89,7 +89,12 @@ export function AccountSearchCombobox({
         // Normalize account fields
         const normalizedCode = normalizeSearchText(account.code);
         const normalizedName = normalizeSearchText(account.name);
-        const normalizedNameKana = account.nameKana ? normalizeSearchText(account.nameKana) : '';
+
+        // Convert nameKana to both hiragana and katakana for flexible matching
+        const nameKanaHiragana = account.nameKana
+          ? normalizeSearchText(katakanaToHiragana(account.nameKana))
+          : '';
+        const nameKanaKatakana = account.nameKana ? normalizeSearchText(account.nameKana) : '';
 
         // Check if search matches any field
         const codeMatch = normalizedCode.includes(normalizedSearch);
@@ -99,13 +104,15 @@ export function AccountSearchCombobox({
           normalizedName.includes(katakanaSearch) ||
           normalizedName.includes(normalizedRomajiHiragana) ||
           normalizedName.includes(normalizedRomajiKatakana);
+
+        // Check kana field against all variations
         const kanaMatch =
-          normalizedNameKana &&
-          (normalizedNameKana.includes(normalizedSearch) ||
-            normalizedNameKana.includes(hiraganaSearch) ||
-            normalizedNameKana.includes(katakanaSearch) ||
-            normalizedNameKana.includes(normalizedRomajiHiragana) ||
-            normalizedNameKana.includes(normalizedRomajiKatakana));
+          account.nameKana &&
+          (nameKanaHiragana.includes(normalizedSearch) ||
+            nameKanaHiragana.includes(hiraganaSearch) ||
+            nameKanaHiragana.includes(normalizedRomajiHiragana) ||
+            nameKanaKatakana.includes(katakanaSearch) ||
+            nameKanaKatakana.includes(normalizedRomajiKatakana));
 
         return codeMatch || nameMatch || kanaMatch;
       });


### PR DESCRIPTION
## 概要

勘定科目検索でローマ字入力（genkin、uriage等）が正しく勘定科目にヒットしない問題を修正しました。

## 問題の詳細

- `genkin`と入力しても「現金」がヒットしない
- `con`や`kon`と入力しても「コンサルティング費」は正しくヒットする
- データベースの`nameKana`フィールドはカタカナ（「ゲンキン」）で保存されている
- 検索ロジックでカタカナとひらがなの変換に問題があった

## 修正内容

### 根本原因
- データベース：`nameKana`は「ゲンキン」（カタカナ）で保存
- 検索変換：`genkin` → `げんきん`（ひらがな）
- `toLowerCase()`後：カタカナをlowerCase()してもひらがなにはならない

### 解決策
`AccountSearchCombobox`コンポーネントの検索ロジックを改善：
1. `nameKana`フィールドをひらがなとカタカナ両方で検索できるよう改善
2. カタカナで保存されている`nameKana`をひらがなに変換してからマッチング
3. 検索パターンもひらがな・カタカナ両方で照合

## テスト

- 13個の単体テストを追加
- 以下のケースをカバー：
  - ローマ字入力：`genkin` → 「現金」
  - ローマ字入力：`uriage` → 「売上高」
  - ローマ字入力：`con` → 「コンサルティング費」
  - 部分一致：`gen` → 「現金」「小口現金」
  - ひらがな・カタカナ・漢字での検索も確認

## チェックリスト

- [x] コードがリントを通過
- [x] 型チェックを通過
- [x] 単体テストを追加
- [x] 既存のテストが通過
- [x] ビルドが成功

Closes #21

🤖 Generated with [Claude Code](https://claude.ai/code)