### PR TITLE
fix: 仕訳一覧取得API（/api/v1/journal-entries）が500エラーを返す問題を修正 (#22)

### DIFF
--- a/apps/api/src/routes/monitoring.routes.ts
+++ b/apps/api/src/routes/monitoring.routes.ts
@@ -1,7 +1,9 @@
-import { createCacheManager, metrics, healthChecker } from '@simple-bookkeeping/shared';
+import { createCacheManager, metrics, healthChecker, Logger } from '@simple-bookkeeping/shared';
 import { Router, Request, Response } from 'express';
 
 import { prisma } from '../lib/prisma';
+
+const logger = new Logger({ component: 'MonitoringRoutes' });
 
 const router = Router();
 
@@ -100,7 +102,8 @@ router.get('/health', async (_req: Request, res: Response) => {
       try {
         await prisma.$queryRaw`SELECT 1`;
         return true;
-      } catch {
+      } catch (error) {
+        logger.error('Health check database error', error as Error);
         return false;
       }
     },
@@ -176,7 +179,8 @@ router.get('/health/readiness', async (_req: Request, res: Response) => {
       status: 'ready',
       database: true,
     });
-  } catch {
+  } catch (error) {
+    logger.error('Database readiness check failed', error as Error);
     res.status(503).json({
       status: 'not_ready',
       database: false,


### PR DESCRIPTION
## 概要

仕訳入力画面（`/dashboard/journal-entries`）にアクセスした際に、APIエンドポイント `/api/v1/journal-entries` が500エラーを返す問題を修正しました。

Fixes #22

## 変更内容

### 1. エラーハンドリングとログ出力の改善

- **auth.ts ミドルウェア**
  - `console.error` を `Logger.error` に置き換え、構造化されたログ出力を実現
  - エラー内容に応じて適切なHTTPステータスコードを返すように改善
  - データベース接続エラー（P2021/P2022）の場合は503エラーを返す
  - 組織が見つからない場合（P2002/P2003）は400エラーを返す

- **journalEntries.controller.ts**
  - `organizationId` のスコープ問題を修正（TypeScriptエラー対応）
  - エラーログに詳細なコンテキスト情報を追加（organizationId, query, userId）
  - Prismaエラーコードに基づいた適切なエラーレスポンスを返すように改善

- **monitoring.routes.ts**
  - ヘルスチェックエンドポイントにエラーログを追加
  - データベース接続問題のデバッグを容易に

## テスト計画

- [x] ローカルでのユニットテスト（`pnpm test`）
- [x] TypeScriptの型チェック（`pnpm typecheck`）
- [x] ESLintチェック（`pnpm lint`）
- [x] ビルドの確認（`pnpm build`）
- [ ] 本番環境（Render）でのAPI動作確認
- [ ] フロントエンド（Vercel）での仕訳一覧画面の動作確認

## 確認項目

- エラーが発生した際に適切なログが出力されること
- データベース接続エラー時に503エラーが返されること
- 組織が設定されていない場合に適切なエラーメッセージが表示されること
- 仕訳一覧が正常に取得できること

🤖 Generated with [Claude Code](https://claude.ai/code)