### PR TITLE
feat: 環境変数設定の明確化と.env.exampleの改善 (#26)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,46 +1,106 @@
-# ========================================
-# Database Configuration
-# ========================================
-# For local development with Docker:
+# ==========================================
+# Simple Bookkeeping 環境変数設定
+# ==========================================
+# このファイルをコピーして.env.localを作成してください:
+# cp .env.example .env.local
+#
+# 環境変数の優先順位（高い順）:
+# 1. .env.local       - ローカル設定（Gitで管理されない）
+# 2. .env.production  - 本番環境設定（Gitで管理されない）
+# 3. .env.development - 開発環境設定
+# 4. .env             - 共通デフォルト値
+# ==========================================
+
+# ------------------------------------------
+# データベース設定
+# ------------------------------------------
+# PostgreSQL接続文字列
+# 形式: postgresql://[user]:[password]@[host]:[port]/[database]?schema=[schema]
+#
+# Dockerを使用したローカル開発:
 DATABASE_URL="postgresql://bookkeeping:bookkeeping@localhost:5432/simple_bookkeeping?schema=public"
-# For local development without Docker:
+#
+# Dockerを使用しないローカル開発:
 # DATABASE_URL="postgresql://postgres:postgres@localhost:5432/simple_bookkeeping?schema=public"
+#
+# 本番環境の例（実際の値は環境に応じて設定）:
+# DATABASE_URL="postgresql://user:password@your-db-host:5432/your-database?schema=public"
 
-# Database Pool Configuration (optional)
-# DB_POOL_SIZE=10              # Connection pool size (default: num_cpus * 2 + 1)
-# DB_POOL_TIMEOUT=10           # Pool timeout in seconds (default: 10)
-# DB_CONNECT_TIMEOUT=30        # Connection timeout in seconds (default: 30)
-# DB_IDLE_TIMEOUT=300          # Idle connection timeout in seconds (default: 300)
+# データベースプール設定（オプション）
+# DB_POOL_SIZE=10              # 接続プールサイズ（デフォルト: CPUコア数 * 2 + 1）
+# DB_POOL_TIMEOUT=10           # プールタイムアウト（秒）（デフォルト: 10）
+# DB_CONNECT_TIMEOUT=30        # 接続タイムアウト（秒）（デフォルト: 30）
+# DB_IDLE_TIMEOUT=300          # アイドル接続タイムアウト（秒）（デフォルト: 300）
 
-# ========================================
-# API Configuration
-# ========================================
+# ------------------------------------------
+# APIサーバー設定 (apps/api)
+# ------------------------------------------
+# APIサーバーのポート番号
 API_PORT=3001
+
+# Node.js環境（development, production, test）
 NODE_ENV=development
 
-# JWT - REQUIRED: Generate secure random strings for production
-# For local development, these default values are fine
+# JWT認証設定
+# 重要: 本番環境では必ず安全なランダム文字列に変更してください
+# 推奨: openssl rand -base64 32 で生成
 JWT_SECRET=local-dev-secret-change-in-production
 JWT_EXPIRES_IN=7d
 JWT_REFRESH_SECRET=local-dev-refresh-secret-change-in-production
 JWT_REFRESH_EXPIRES_IN=30d
 
-# CORS Configuration
+# CORS設定
+# カンマ区切りで複数のオリジンを指定可能
+# 例: CORS_ORIGIN="http://localhost:3000,https://your-domain.com"
 CORS_ORIGIN=http://localhost:3000
 
-# ========================================
-# Frontend Configuration
-# ========================================
-# IMPORTANT: Include full path with /api/v1
+# ログレベル（debug, info, warn, error）
+LOG_LEVEL=info
+
+# Swagger APIドキュメントの有効化
+ENABLE_SWAGGER=true
+
+# ------------------------------------------
+# フロントエンド設定 (apps/web)
+# ------------------------------------------
+# APIのベースURL
+# 重要: 必ず /api/v1 を含む完全なパスを指定してください
+# 正: http://localhost:3001/api/v1
+# 誤: http://localhost:3001
 NEXT_PUBLIC_API_URL=http://localhost:3001/api/v1
 
-# Redis (optional)
+# アプリケーションのベースURL
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# ------------------------------------------
+# キャッシュ設定（オプション）
+# ------------------------------------------
+# Redis接続URL（キャッシュ機能を使用する場合）
 REDIS_URL=redis://localhost:6379
 
-# Vercel API Token (optional, for deployment status checks)
-# Get your token from: https://vercel.com/account/tokens
+# ------------------------------------------
+# デプロイメント監視（オプション）
+# ------------------------------------------
+# Vercel APIトークン（デプロイメント状態確認用）
+# 取得方法: https://vercel.com/account/tokens
 VERCEL_TOKEN=your-vercel-token-here
 
-# Render API Token (optional, for deployment status checks)
-# Get your token from: https://dashboard.render.com/u/settings
+# Render APIキー（デプロイメント状態確認用）
+# 取得方法: https://dashboard.render.com/u/settings
 RENDER_API_KEY=rnd_xxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# ------------------------------------------
+# 将来の拡張用（現在は未使用）
+# ------------------------------------------
+# メール送信設定
+# SMTP_HOST=smtp.example.com
+# SMTP_PORT=587
+# SMTP_USER=your-email@example.com
+# SMTP_PASS=your-password
+# SMTP_FROM=noreply@example.com
+
+# ファイルストレージ設定
+# STORAGE_TYPE=local
+# STORAGE_PATH=./uploads
+# AWS_S3_BUCKET=your-bucket-name
+# AWS_S3_REGION=ap-northeast-1

--- a/README.md
+++ b/README.md
@@ -108,12 +108,18 @@ cd simple-bookkeeping
 pnpm install
 
 # 環境変数の設定
-cp .env.example .env
+cp .env.example .env.local
+# 重要: .env.localを編集して必要な値を設定
+# 特にNEXT_PUBLIC_API_URLは必ず/api/v1を含めてください
+# 詳細は docs/ENVIRONMENT_VARIABLES.md を参照
 
 # PostgreSQLの起動（別途インストールが必要）
 # データベースのセットアップ
 pnpm db:migrate
 pnpm db:seed
+
+# 環境変数の検証（オプション）
+pnpm env:validate
 
 # 開発サーバーの起動
 pnpm dev
@@ -148,6 +154,7 @@ API_PORT=3011  # デフォルト: 3001
 
 ### 📋 開発・運用
 
+- [環境変数ガイド](./docs/ENVIRONMENT_VARIABLES.md) - 環境変数の詳細設定
 - [実装計画](./docs/implementation-plan/roadmap.md) - フェーズ別開発計画
 - [技術スタック選定書](./docs/implementation-plan/tech-stack.md) - 技術選定の理由
 - [Docker環境構築](./docs/docker-setup.md) - Docker開発環境

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -1,0 +1,346 @@
+# 環境変数ガイド
+
+このドキュメントでは、Simple Bookkeepingプロジェクトで使用する環境変数について詳しく説明します。
+
+## 目次
+
+- [クイックスタート](#クイックスタート)
+- [環境変数ファイルの使い分け](#環境変数ファイルの使い分け)
+- [必須環境変数](#必須環境変数)
+- [オプション環境変数](#オプション環境変数)
+- [環境別の設定例](#環境別の設定例)
+- [トラブルシューティング](#トラブルシューティング)
+- [セキュリティ](#セキュリティ)
+
+## クイックスタート
+
+### 1. 環境変数ファイルのセットアップ
+
+```bash
+# .env.exampleをコピーして.env.localを作成
+cp .env.example .env.local
+
+# .env.localを編集して必要な値を設定
+# 特に重要な設定:
+# - DATABASE_URL: データベース接続文字列
+# - NEXT_PUBLIC_API_URL: APIのベースURL（必ず/api/v1を含める）
+```
+
+### 2. 環境変数の確認
+
+```bash
+# APIサーバー側の環境変数確認
+cd apps/api && node -e "console.log('DATABASE_URL:', process.env.DATABASE_URL)"
+
+# フロントエンド側の環境変数確認
+cd apps/web && node -e "console.log('API_URL:', process.env.NEXT_PUBLIC_API_URL)"
+
+# 環境変数のバリデーション（実装後）
+pnpm env:validate
+```
+
+## 環境変数ファイルの使い分け
+
+| ファイル名         | 用途               | Git管理 | 優先度   | 説明                                   |
+| ------------------ | ------------------ | ------- | -------- | -------------------------------------- |
+| `.env.example`     | サンプル設定       | ✅      | -        | すべての環境変数のテンプレートと説明   |
+| `.env`             | 共通のデフォルト値 | ❌      | 低       | すべての環境で共通のデフォルト値       |
+| `.env.local`       | ローカル開発用     | ❌      | **最高** | 個人のローカル開発環境の設定           |
+| `.env.development` | 開発環境用         | ✅      | 中       | 開発環境共通の設定                     |
+| `.env.production`  | 本番環境用         | ❌      | 中       | 本番環境の設定（絶対にコミットしない） |
+| `.env.test`        | テスト用           | ✅      | 中       | テスト実行時の設定                     |
+
+### 環境変数の優先順位（Next.js）
+
+1. `process.env`に直接設定された値
+2. `.env.$(NODE_ENV).local`（例: `.env.production.local`）
+3. `.env.local`（本番環境では読み込まれない）
+4. `.env.$(NODE_ENV)`（例: `.env.production`）
+5. `.env`
+
+## 必須環境変数
+
+### データベース設定
+
+#### `DATABASE_URL`
+
+- **説明**: PostgreSQLデータベースへの接続文字列
+- **形式**: `postgresql://[user]:[password]@[host]:[port]/[database]?schema=[schema]`
+- **例**:
+
+  ```
+  # ローカル開発（Docker使用）
+  DATABASE_URL="postgresql://bookkeeping:bookkeeping@localhost:5432/simple_bookkeeping?schema=public"
+
+  # 本番環境
+  DATABASE_URL="postgresql://prod_user:secure_password@db.example.com:5432/prod_db?schema=public"
+  ```
+
+### APIサーバー設定
+
+#### `API_PORT`
+
+- **説明**: APIサーバーのポート番号
+- **デフォルト**: `3001`
+- **注意**: フロントエンド（ポート3000）と重複しないように設定
+
+#### `JWT_SECRET`
+
+- **説明**: JWT署名用の秘密鍵
+- **重要**: 本番環境では必ず変更する
+- **生成方法**: `openssl rand -base64 32`
+- **最小長**: 32文字
+
+#### `JWT_REFRESH_SECRET`
+
+- **説明**: リフレッシュトークン用の秘密鍵
+- **重要**: `JWT_SECRET`とは異なる値を設定
+- **生成方法**: `openssl rand -base64 32`
+
+### フロントエンド設定
+
+#### `NEXT_PUBLIC_API_URL`
+
+- **説明**: フロントエンドからAPIにアクセスするためのURL
+- **形式**: `http[s]://[host]:[port]/api/v1`
+- **重要**: **必ず `/api/v1` を含めてください**
+- **例**:
+
+  ```
+  # ✅ 正しい
+  NEXT_PUBLIC_API_URL="http://localhost:3001/api/v1"
+
+  # ❌ 間違い（/api/v1がない）
+  NEXT_PUBLIC_API_URL="http://localhost:3001"
+  ```
+
+## オプション環境変数
+
+### Node.js環境設定
+
+#### `NODE_ENV`
+
+- **説明**: アプリケーションの実行環境
+- **値**: `development` | `production` | `test`
+- **デフォルト**: `development`
+
+#### `LOG_LEVEL`
+
+- **説明**: ログ出力レベル
+- **値**: `debug` | `info` | `warn` | `error`
+- **デフォルト**: `info`
+
+### セキュリティ設定
+
+#### `CORS_ORIGIN`
+
+- **説明**: CORS許可オリジン
+- **形式**: カンマ区切りで複数指定可能
+- **例**: `"http://localhost:3000,https://app.example.com"`
+
+#### `JWT_EXPIRES_IN`
+
+- **説明**: アクセストークンの有効期限
+- **デフォルト**: `7d`
+- **形式**: 数値 + 単位（s, m, h, d）
+
+#### `JWT_REFRESH_EXPIRES_IN`
+
+- **説明**: リフレッシュトークンの有効期限
+- **デフォルト**: `30d`
+
+### キャッシュ設定
+
+#### `REDIS_URL`
+
+- **説明**: Redis接続URL（キャッシュ機能使用時）
+- **形式**: `redis://[user]:[password]@[host]:[port]/[database]`
+- **例**: `redis://localhost:6379`
+
+### デプロイメント監視
+
+#### `VERCEL_TOKEN`
+
+- **説明**: Vercel APIアクセストークン
+- **用途**: デプロイメント状態の確認
+- **取得**: https://vercel.com/account/tokens
+
+#### `RENDER_API_KEY`
+
+- **説明**: Render APIキー
+- **用途**: デプロイメント状態の確認
+- **取得**: https://dashboard.render.com/u/settings
+
+## 環境別の設定例
+
+### ローカル開発環境（.env.local）
+
+```bash
+# データベース（ローカルDocker）
+DATABASE_URL="postgresql://bookkeeping:bookkeeping@localhost:5432/simple_bookkeeping?schema=public"
+
+# API設定
+API_PORT=3001
+NODE_ENV=development
+JWT_SECRET=local-dev-secret-key
+JWT_REFRESH_SECRET=local-dev-refresh-secret
+CORS_ORIGIN=http://localhost:3000
+LOG_LEVEL=debug
+
+# フロントエンド
+NEXT_PUBLIC_API_URL=http://localhost:3001/api/v1
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# 開発ツール
+ENABLE_SWAGGER=true
+```
+
+### テスト環境（.env.test）
+
+```bash
+# テスト用データベース（インメモリまたはテスト専用DB）
+DATABASE_URL="postgresql://test:test@localhost:5432/test_db?schema=public"
+
+# テスト用設定
+NODE_ENV=test
+JWT_SECRET=test-secret
+JWT_REFRESH_SECRET=test-refresh-secret
+LOG_LEVEL=error
+
+# API URL
+NEXT_PUBLIC_API_URL=http://localhost:3001/api/v1
+```
+
+### 本番環境（.env.production）
+
+```bash
+# 本番データベース（実際の値は環境に応じて設定）
+DATABASE_URL="postgresql://prod_user:${DB_PASSWORD}@prod-db.example.com:5432/production_db?schema=public"
+
+# セキュリティ設定
+NODE_ENV=production
+JWT_SECRET=${JWT_SECRET_PROD}  # 環境変数から取得
+JWT_REFRESH_SECRET=${JWT_REFRESH_SECRET_PROD}
+JWT_EXPIRES_IN=1h
+JWT_REFRESH_EXPIRES_IN=7d
+CORS_ORIGIN=https://app.example.com
+LOG_LEVEL=warn
+
+# 本番API
+NEXT_PUBLIC_API_URL=https://api.example.com/api/v1
+NEXT_PUBLIC_APP_URL=https://app.example.com
+
+# 本番では無効化
+ENABLE_SWAGGER=false
+```
+
+## トラブルシューティング
+
+### よくある問題と解決方法
+
+#### 1. APIへの接続ができない
+
+**症状**: フロントエンドからAPIにリクエストを送信するとエラーになる
+
+**確認事項**:
+
+- `NEXT_PUBLIC_API_URL`が正しく設定されているか
+- URLに`/api/v1`が含まれているか
+- APIサーバーが起動しているか（`pnpm --filter api dev`）
+- CORSの設定が正しいか
+
+```bash
+# 確認コマンド
+echo $NEXT_PUBLIC_API_URL  # http://localhost:3001/api/v1 と表示されるべき
+curl $NEXT_PUBLIC_API_URL/health  # APIのヘルスチェック
+```
+
+#### 2. データベース接続エラー
+
+**症状**: `PrismaClientInitializationError`などのエラー
+
+**確認事項**:
+
+- PostgreSQLが起動しているか
+- `DATABASE_URL`の形式が正しいか
+- データベースが存在するか
+- ユーザー権限が適切か
+
+```bash
+# PostgreSQL接続テスト
+psql $DATABASE_URL -c "SELECT 1"
+
+# Prismaの接続テスト
+pnpm --filter database prisma db push --skip-generate
+```
+
+#### 3. JWT認証エラー
+
+**症状**: ログインはできるが、その後のリクエストが401エラー
+
+**確認事項**:
+
+- `JWT_SECRET`が設定されているか
+- APIとフロントエンドで同じ`JWT_SECRET`を使用しているか
+- トークンの有効期限が切れていないか
+
+#### 4. 環境変数が読み込まれない
+
+**症状**: `undefined`が返される
+
+**確認事項**:
+
+- ファイル名が正しいか（`.env.local`など）
+- Next.jsの場合、`NEXT_PUBLIC_`プレフィックスが付いているか
+- サーバーを再起動したか
+- `.env.local`が`.gitignore`に含まれているか（セキュリティ）
+
+```bash
+# 環境変数の確認
+pnpm env:validate  # バリデーションスクリプト実行
+```
+
+## セキュリティ
+
+### 環境変数のベストプラクティス
+
+1. **機密情報の管理**
+   - `.env.local`と`.env.production`は絶対にGitにコミットしない
+   - `.gitignore`に必ず含める
+   - 機密情報は環境変数管理サービス（Vercel、Render等）で設定
+
+2. **秘密鍵の生成**
+
+   ```bash
+   # 安全なランダム文字列の生成
+   openssl rand -base64 32
+
+   # または
+   node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+   ```
+
+3. **アクセス制限**
+   - 本番環境の環境変数は必要最小限の人のみアクセス可能にする
+   - 定期的に秘密鍵をローテーションする
+
+4. **環境変数の分離**
+   - 開発環境と本番環境で異なる値を使用
+   - テスト環境では専用のダミー値を使用
+
+### 環境変数のチェックリスト
+
+- [ ] `.env.local`を作成した
+- [ ] `DATABASE_URL`を正しく設定した
+- [ ] `NEXT_PUBLIC_API_URL`に`/api/v1`を含めた
+- [ ] JWT秘密鍵を安全な値に変更した
+- [ ] `.env.local`が`.gitignore`に含まれている
+- [ ] 本番環境用の環境変数を別途管理している
+- [ ] CORSの設定が適切である
+- [ ] ログレベルが環境に応じて設定されている
+
+## 関連ドキュメント
+
+- [README.md](../README.md) - プロジェクトの概要
+- [CLAUDE.md](../CLAUDE.md) - 開発ガイドライン
+- [deployment/detailed-guide.md](./deployment/detailed-guide.md) - デプロイメントガイド
+- [npm-scripts-guide.md](./npm-scripts-guide.md) - npmスクリプトガイド

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
     "db:init": "./scripts/init-db.sh",
     "db:migrate": "turbo run db:migrate",
     "db:seed": "turbo run db:seed",
+    "env:validate": "tsx scripts/validate-env.ts",
+    "env:validate:api": "tsx scripts/validate-env.ts --api",
+    "env:validate:web": "tsx scripts/validate-env.ts --web",
+    "env:validate:strict": "tsx scripts/validate-env.ts --strict",
     "docker:up": "docker-compose up -d",
     "docker:down": "docker-compose down",
     "docker:logs": "docker-compose logs -f",
@@ -69,6 +73,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.1.4",
     "prettier": "^3.6.2",
+    "tsx": "^4.20.3",
     "turbo": "^2.5.5",
     "typescript": "^5.9.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      tsx:
+        specifier: ^4.20.3
+        version: 4.20.3
       turbo:
         specifier: ^2.5.5
         version: 2.5.5

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -1,0 +1,239 @@
+#!/usr/bin/env tsx
+/**
+ * 環境変数バリデーションスクリプト
+ *
+ * 使用方法:
+ *   pnpm env:validate          # 全環境変数をチェック
+ *   pnpm env:validate --api     # APIサーバーの環境変数のみチェック
+ *   pnpm env:validate --web     # フロントエンドの環境変数のみチェック
+ *   pnpm env:validate --strict  # 警告もエラーとして扱う
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+// カラー出力用のヘルパー
+const colors = {
+  reset: '\x1b[0m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[36m',
+  bold: '\x1b[1m',
+};
+
+const log = {
+  error: (msg: string) => console.error(`${colors.red}❌ ${msg}${colors.reset}`),
+  success: (msg: string) => console.error(`${colors.green}✅ ${msg}${colors.reset}`), // Use console.error to be consistent with linting rules
+  warning: (msg: string) => console.error(`${colors.yellow}⚠️  ${msg}${colors.reset}`), // Use console.error to be consistent with linting rules
+  info: (msg: string) => console.error(`${colors.blue}ℹ️  ${msg}${colors.reset}`), // Use console.error to be consistent with linting rules
+  header: (msg: string) => console.error(`\n${colors.bold}${colors.blue}${msg}${colors.reset}`), // Use console.error to be consistent with linting rules
+};
+
+// コマンドライン引数の解析
+const args = process.argv.slice(2);
+const checkApi = args.includes('--api');
+const checkWeb = args.includes('--web');
+const strictMode = args.includes('--strict');
+const checkAll = !checkApi && !checkWeb;
+
+// 環境変数ファイルの読み込み
+const rootDir = path.join(__dirname, '..');
+const envFiles = ['.env', '.env.local', `.env.${process.env.NODE_ENV || 'development'}`];
+
+// 環境変数を読み込む
+// Note: dotenvは不要（process.envは既に利用可能）
+envFiles.forEach((file) => {
+  const filePath = path.join(rootDir, file);
+  if (fs.existsSync(filePath)) {
+    // 環境変数ファイルを直接読み込んで解析
+    const envConfig = fs.readFileSync(filePath, 'utf8');
+    envConfig.split('\n').forEach((line) => {
+      const trimmed = line.trim();
+      if (trimmed && !trimmed.startsWith('#')) {
+        const [key, ...valueParts] = trimmed.split('=');
+        if (key && valueParts.length > 0) {
+          const value = valueParts.join('=').replace(/^["']|["']$/g, '');
+          if (!process.env[key]) {
+            process.env[key] = value;
+          }
+        }
+      }
+    });
+    log.info(`読み込み: ${file}`);
+  }
+});
+
+// バリデーション実行
+let hasError = false;
+let hasWarning = false;
+
+log.header('環境変数バリデーション開始');
+
+// データベース設定のチェック
+if (checkAll || checkApi) {
+  log.header('データベース設定');
+
+  if (!process.env.DATABASE_URL) {
+    log.error('DATABASE_URLが設定されていません');
+    hasError = true;
+  } else if (!process.env.DATABASE_URL.startsWith('postgresql://')) {
+    log.error('DATABASE_URLはpostgresql://で始まる必要があります');
+    hasError = true;
+  } else {
+    log.success('データベース設定: OK');
+  }
+}
+
+// APIサーバー設定のチェック
+if (checkAll || checkApi) {
+  log.header('APIサーバー設定');
+
+  // JWT_SECRET
+  if (!process.env.JWT_SECRET) {
+    log.error('JWT_SECRETが設定されていません');
+    hasError = true;
+  } else if (process.env.JWT_SECRET.length < 32) {
+    log.error('JWT_SECRETは最低32文字以上にしてください（セキュリティ）');
+    hasError = true;
+  } else if (process.env.JWT_SECRET === 'local-dev-secret-change-in-production') {
+    if (process.env.NODE_ENV === 'production') {
+      log.error('本番環境でデフォルトのJWT_SECRETを使用しています！');
+      hasError = true;
+    } else {
+      log.warning(
+        '開発環境でデフォルトのJWT_SECRETを使用しています（本番環境では変更してください）'
+      );
+      hasWarning = true;
+    }
+  }
+
+  // JWT_REFRESH_SECRET
+  if (!process.env.JWT_REFRESH_SECRET) {
+    log.error('JWT_REFRESH_SECRETが設定されていません');
+    hasError = true;
+  } else if (process.env.JWT_REFRESH_SECRET.length < 32) {
+    log.error('JWT_REFRESH_SECRETは最低32文字以上にしてください');
+    hasError = true;
+  } else if (process.env.JWT_REFRESH_SECRET === 'local-dev-refresh-secret-change-in-production') {
+    if (process.env.NODE_ENV === 'production') {
+      log.error('本番環境でデフォルトのJWT_REFRESH_SECRETを使用しています！');
+      hasError = true;
+    }
+  }
+
+  // CORS_ORIGIN (development環境ではオプション)
+  if (!process.env.CORS_ORIGIN) {
+    if (process.env.NODE_ENV === 'production') {
+      log.error('本番環境ではCORS_ORIGINが必須です');
+      hasError = true;
+    } else {
+      log.warning(
+        'CORS_ORIGINが設定されていません（開発環境では localhost:3000 がデフォルトで使用されます）'
+      );
+      hasWarning = true;
+    }
+  }
+
+  // API_PORT
+  if (process.env.API_PORT) {
+    const port = parseInt(process.env.API_PORT, 10);
+    if (isNaN(port) || port < 1 || port > 65535) {
+      log.error('API_PORTは1-65535の範囲で指定してください');
+      hasError = true;
+    }
+  }
+
+  // NODE_ENV
+  if (process.env.NODE_ENV) {
+    if (!['development', 'production', 'test'].includes(process.env.NODE_ENV)) {
+      log.warning(`NODE_ENVの値が不正です: ${process.env.NODE_ENV}`);
+      hasWarning = true;
+    }
+  }
+
+  if (!hasError) {
+    log.success('APIサーバー設定: OK');
+  }
+}
+
+// フロントエンド設定のチェック
+if (checkAll || checkWeb) {
+  log.header('フロントエンド設定');
+
+  // NEXT_PUBLIC_API_URL
+  if (!process.env.NEXT_PUBLIC_API_URL) {
+    log.error('NEXT_PUBLIC_API_URLが設定されていません');
+    hasError = true;
+  } else {
+    try {
+      new URL(process.env.NEXT_PUBLIC_API_URL);
+      if (!process.env.NEXT_PUBLIC_API_URL.endsWith('/api/v1')) {
+        log.error(
+          'NEXT_PUBLIC_API_URLは /api/v1 で終わる必要があります（例: http://localhost:3001/api/v1）'
+        );
+        hasError = true;
+      } else {
+        log.success('フロントエンド設定: OK');
+      }
+    } catch {
+      log.error('NEXT_PUBLIC_API_URLが有効なURLではありません');
+      hasError = true;
+    }
+  }
+
+  // NEXT_PUBLIC_APP_URL
+  if (process.env.NEXT_PUBLIC_APP_URL) {
+    try {
+      new URL(process.env.NEXT_PUBLIC_APP_URL);
+    } catch {
+      log.warning('NEXT_PUBLIC_APP_URLが有効なURLではありません');
+      hasWarning = true;
+    }
+  }
+
+  // API URLの一貫性チェック
+  if (process.env.CORS_ORIGIN && process.env.NEXT_PUBLIC_APP_URL) {
+    const corsOrigins = process.env.CORS_ORIGIN.split(',').map((o) => o.trim());
+    if (!corsOrigins.includes(process.env.NEXT_PUBLIC_APP_URL)) {
+      log.warning(
+        `NEXT_PUBLIC_APP_URL (${process.env.NEXT_PUBLIC_APP_URL}) がCORS_ORIGINに含まれていません`
+      );
+      hasWarning = true;
+    }
+  }
+}
+
+// オプション設定のチェック
+if (checkAll) {
+  log.header('オプション設定');
+
+  // REDIS_URL
+  if (process.env.REDIS_URL) {
+    if (!process.env.REDIS_URL.startsWith('redis://')) {
+      log.warning('REDIS_URLはredis://で始まる必要があります');
+      hasWarning = true;
+    }
+  }
+
+  if (!hasWarning) {
+    log.success('オプション設定: OK');
+  }
+}
+
+// 結果の表示
+log.header('バリデーション結果');
+
+if (!hasError && !hasWarning) {
+  log.success('すべての環境変数が正しく設定されています！');
+  process.exit(0);
+} else if (hasError) {
+  log.error('環境変数にエラーがあります。修正してください。');
+  process.exit(1);
+} else if (hasWarning && strictMode) {
+  log.error('警告が見つかりました（strictモード）');
+  process.exit(1);
+} else {
+  log.warning('警告が見つかりましたが、続行可能です。');
+  process.exit(0);
+}


### PR DESCRIPTION
## Summary

- 🔧 包括的な.env.exampleファイルを作成し、各環境変数に日本語の詳細説明を追加
- 📝 環境変数の詳細ガイド（docs/ENVIRONMENT_VARIABLES.md）を作成
- ✅ 環境変数バリデーションスクリプト（`pnpm env:validate`）を実装
- 📚 READMEに環境変数設定の説明を追加

## 解決した問題

Issue #26で報告された、環境変数の設定が不明確で、特に`NEXT_PUBLIC_API_URL`の設定で混乱が生じていた問題を解決しました。

特に以下の点を改善：
- `NEXT_PUBLIC_API_URL`には必ず`/api/v1`を含める必要があることを明確化
- 各環境変数の役割、形式、サンプル値を詳細に説明
- バリデーションスクリプトにより設定ミスを早期に発見可能に

## Test plan

- [x] `pnpm env:validate`コマンドが正しく動作すること
- [x] 環境変数の設定ミスがある場合にエラーが表示されること
- [x] 開発環境と本番環境で適切な警告・エラーが表示されること
- [x] ドキュメントが読みやすく理解しやすいこと

## Changes

### 新規作成ファイル
- `docs/ENVIRONMENT_VARIABLES.md` - 環境変数の詳細ガイド
- `scripts/validate-env.ts` - 環境変数バリデーションスクリプト

### 更新ファイル
- `.env.example` - 包括的な環境変数テンプレート（日本語コメント付き）
- `package.json` - env:validateコマンドの追加
- `README.md` - 環境変数設定の説明を追加

🤖 Generated with [Claude Code](https://claude.ai/code)