### PR TITLE
feat: 組織設定機能の実装 (#78)

### DIFF
--- a/apps/api/src/routes/organizations.routes.ts
+++ b/apps/api/src/routes/organizations.routes.ts
@@ -72,6 +72,23 @@ router.post(
   organizationsController.inviteUser as RouteHandler
 );
 
+// Get organization members (All members can view)
+router.get('/:id/members', organizationsController.getOrganizationMembers as RouteHandler);
+
+// Update user role in organization (Admin only)
+router.put(
+  '/:id/members/:userId',
+  authorize(UserRole.ADMIN),
+  validate(
+    z.object({
+      body: z.object({
+        role: z.enum([UserRole.ADMIN, UserRole.ACCOUNTANT, UserRole.VIEWER]),
+      }),
+    })
+  ),
+  organizationsController.updateUserRole as RouteHandler
+);
+
 // Remove user from organization (Admin only)
 router.delete(
   '/:id/users/:userId',

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -49,6 +49,7 @@
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.62.0",
     "react-hot-toast": "^2.5.2",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "wanakana": "^5.3.1",

--- a/apps/web/src/app/dashboard/settings/organization/members/page.tsx
+++ b/apps/web/src/app/dashboard/settings/organization/members/page.tsx
@@ -1,0 +1,469 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { UserRole } from '@simple-bookkeeping/database';
+import { AlertTriangle, Loader2, MoreHorizontal, Plus, Shield, UserMinus } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { useAuth } from '@/contexts/auth-context';
+import { apiClient as api } from '@/lib/api-client';
+
+const inviteSchema = z.object({
+  email: z.string().email('有効なメールアドレスを入力してください'),
+  role: z.enum(['ADMIN', 'ACCOUNTANT', 'VIEWER']),
+});
+
+type InviteFormData = z.infer<typeof inviteSchema>;
+
+interface Member {
+  id: string;
+  email: string;
+  name: string | null;
+  role: UserRole;
+  joinedAt: string;
+}
+
+const roleLabels = {
+  ADMIN: '管理者',
+  ACCOUNTANT: '経理担当',
+  VIEWER: '閲覧者',
+};
+
+const roleColors = {
+  ADMIN: 'destructive',
+  ACCOUNTANT: 'default',
+  VIEWER: 'secondary',
+} as const;
+
+export default function OrganizationMembersPage() {
+  const { user, currentOrganization } = useAuth();
+  const [members, setMembers] = useState<Member[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isInviting, setIsInviting] = useState(false);
+  const [isRemoving, setIsRemoving] = useState(false);
+  const [isUpdatingRole, setIsUpdatingRole] = useState(false);
+  const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
+  const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
+  const [roleDialogOpen, setRoleDialogOpen] = useState(false);
+  const [selectedMember, setSelectedMember] = useState<Member | null>(null);
+  const [selectedRole, setSelectedRole] = useState<UserRole>(UserRole.VIEWER);
+
+  const form = useForm<InviteFormData>({
+    resolver: zodResolver(inviteSchema),
+    defaultValues: {
+      email: '',
+      role: UserRole.VIEWER,
+    },
+  });
+
+  const currentUserRole = user?.currentOrganization?.role;
+  const isAdmin = currentUserRole === 'ADMIN';
+
+  useEffect(() => {
+    fetchMembers();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentOrganization]);
+
+  const fetchMembers = async () => {
+    if (!currentOrganization) return;
+
+    setIsLoading(true);
+    try {
+      const response = await api.get<{ data: Member[] }>(
+        `/organizations/${currentOrganization.id}/members`
+      );
+      if (response.data?.data) {
+        setMembers(response.data.data);
+      }
+    } catch (error) {
+      console.error('Failed to fetch members:', error);
+      toast.error('メンバー一覧の取得に失敗しました');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const onInviteSubmit = async (data: InviteFormData) => {
+    if (!currentOrganization) return;
+
+    setIsInviting(true);
+    try {
+      await api.post(`/organizations/${currentOrganization.id}/invite`, data);
+      toast.success('ユーザーを招待しました');
+      setInviteDialogOpen(false);
+      form.reset();
+      fetchMembers();
+    } catch (error: any) {
+      console.error('Failed to invite user:', error);
+      const errorMessage = error.response?.data?.error?.message || 'ユーザーの招待に失敗しました';
+      toast.error(errorMessage);
+    } finally {
+      setIsInviting(false);
+    }
+  };
+
+  const handleRemoveMember = async () => {
+    if (!currentOrganization || !selectedMember) return;
+
+    setIsRemoving(true);
+    try {
+      await api.delete(`/organizations/${currentOrganization.id}/users/${selectedMember.id}`);
+      toast.success('メンバーを削除しました');
+      setRemoveDialogOpen(false);
+      setSelectedMember(null);
+      fetchMembers();
+    } catch (error: any) {
+      console.error('Failed to remove member:', error);
+      const errorMessage = error.response?.data?.error?.message || 'メンバーの削除に失敗しました';
+      toast.error(errorMessage);
+    } finally {
+      setIsRemoving(false);
+    }
+  };
+
+  const handleUpdateRole = async () => {
+    if (!currentOrganization || !selectedMember) return;
+
+    setIsUpdatingRole(true);
+    try {
+      await api.put(`/organizations/${currentOrganization.id}/members/${selectedMember.id}`, {
+        role: selectedRole,
+      });
+      toast.success('ロールを更新しました');
+      setRoleDialogOpen(false);
+      setSelectedMember(null);
+      fetchMembers();
+    } catch (error: any) {
+      console.error('Failed to update role:', error);
+      const errorMessage = error.response?.data?.error?.message || 'ロールの更新に失敗しました';
+      toast.error(errorMessage);
+    } finally {
+      setIsUpdatingRole(false);
+    }
+  };
+
+  const openRoleDialog = (member: Member) => {
+    setSelectedMember(member);
+    setSelectedRole(member.role);
+    setRoleDialogOpen(true);
+  };
+
+  const openRemoveDialog = (member: Member) => {
+    setSelectedMember(member);
+    setRemoveDialogOpen(true);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <Loader2 className="h-8 w-8 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto py-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold">メンバー管理</h1>
+        <p className="mt-2 text-muted-foreground">組織のメンバーとその権限を管理します</p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>組織メンバー</CardTitle>
+              <CardDescription>
+                現在 {members.length} 名のメンバーが登録されています
+              </CardDescription>
+            </div>
+            {isAdmin && (
+              <Button onClick={() => setInviteDialogOpen(true)}>
+                <Plus className="mr-2 h-4 w-4" />
+                メンバーを招待
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>名前</TableHead>
+                <TableHead>メールアドレス</TableHead>
+                <TableHead>ロール</TableHead>
+                <TableHead>参加日</TableHead>
+                {isAdmin && <TableHead className="w-[100px]">操作</TableHead>}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {members.map((member) => {
+                const isCurrentUser = member.id === user?.id;
+                const adminCount = members.filter((m) => m.role === UserRole.ADMIN).length;
+                const isLastAdmin = member.role === UserRole.ADMIN && adminCount === 1;
+
+                return (
+                  <TableRow key={member.id}>
+                    <TableCell className="font-medium">
+                      {member.name || '未設定'}
+                      {isCurrentUser && (
+                        <span className="ml-2 text-xs text-muted-foreground">(あなた)</span>
+                      )}
+                    </TableCell>
+                    <TableCell>{member.email}</TableCell>
+                    <TableCell>
+                      <Badge variant={roleColors[member.role]}>
+                        {member.role === UserRole.ADMIN && <Shield className="mr-1 h-3 w-3" />}
+                        {roleLabels[member.role]}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>{new Date(member.joinedAt).toLocaleDateString('ja-JP')}</TableCell>
+                    {isAdmin && (
+                      <TableCell>
+                        {!isCurrentUser && (
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button variant="ghost" size="icon">
+                                <MoreHorizontal className="h-4 w-4" />
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                              <DropdownMenuLabel>操作</DropdownMenuLabel>
+                              <DropdownMenuSeparator />
+                              <DropdownMenuItem
+                                onClick={() => openRoleDialog(member)}
+                                disabled={isLastAdmin}
+                              >
+                                <Shield className="mr-2 h-4 w-4" />
+                                ロール変更
+                              </DropdownMenuItem>
+                              <DropdownMenuItem
+                                onClick={() => openRemoveDialog(member)}
+                                disabled={isLastAdmin}
+                                className="text-destructive"
+                              >
+                                <UserMinus className="mr-2 h-4 w-4" />
+                                削除
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        )}
+                      </TableCell>
+                    )}
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      {/* Invite Dialog */}
+      <Dialog open={inviteDialogOpen} onOpenChange={setInviteDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>メンバーを招待</DialogTitle>
+            <DialogDescription>
+              メールアドレスを入力して、新しいメンバーを組織に招待します
+            </DialogDescription>
+          </DialogHeader>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onInviteSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>メールアドレス</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        type="email"
+                        placeholder="user@example.com"
+                        disabled={isInviting}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="role"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>ロール</FormLabel>
+                    <Select onValueChange={field.onChange} defaultValue={field.value}>
+                      <FormControl>
+                        <SelectTrigger disabled={isInviting}>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value={UserRole.ADMIN}>
+                          <div className="flex items-center">
+                            <Shield className="mr-2 h-4 w-4" />
+                            管理者
+                          </div>
+                        </SelectItem>
+                        <SelectItem value={UserRole.ACCOUNTANT}>経理担当</SelectItem>
+                        <SelectItem value={UserRole.VIEWER}>閲覧者</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setInviteDialogOpen(false)}
+                  disabled={isInviting}
+                >
+                  キャンセル
+                </Button>
+                <Button type="submit" disabled={isInviting}>
+                  {isInviting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  招待
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Role Change Dialog */}
+      <Dialog open={roleDialogOpen} onOpenChange={setRoleDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>ロール変更</DialogTitle>
+            <DialogDescription>
+              {selectedMember?.name || selectedMember?.email} のロールを変更します
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <label className="text-sm font-medium">新しいロール</label>
+              <Select
+                value={selectedRole}
+                onValueChange={(value) => setSelectedRole(value as UserRole)}
+              >
+                <SelectTrigger disabled={isUpdatingRole}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={UserRole.ADMIN}>
+                    <div className="flex items-center">
+                      <Shield className="mr-2 h-4 w-4" />
+                      管理者
+                    </div>
+                  </SelectItem>
+                  <SelectItem value={UserRole.ACCOUNTANT}>経理担当</SelectItem>
+                  <SelectItem value={UserRole.VIEWER}>閲覧者</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setRoleDialogOpen(false)}
+              disabled={isUpdatingRole}
+            >
+              キャンセル
+            </Button>
+            <Button onClick={handleUpdateRole} disabled={isUpdatingRole}>
+              {isUpdatingRole && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              変更
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Remove Member Dialog */}
+      <AlertDialog open={removeDialogOpen} onOpenChange={setRemoveDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center">
+              <AlertTriangle className="mr-2 h-5 w-5 text-destructive" />
+              メンバーを削除
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {selectedMember?.name || selectedMember?.email} を組織から削除してもよろしいですか？
+              この操作は取り消せません。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isRemoving}>キャンセル</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleRemoveMember}
+              disabled={isRemoving}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isRemoving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              削除
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/settings/organization/page.tsx
+++ b/apps/web/src/app/dashboard/settings/organization/page.tsx
@@ -1,0 +1,320 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Loader2 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useAuth } from '@/contexts/auth-context';
+import { apiClient as api } from '@/lib/api-client';
+
+const organizationSchema = z.object({
+  name: z.string().min(1, '組織名は必須です'),
+  taxId: z.string().optional(),
+  address: z.string().optional(),
+  phone: z.string().optional(),
+  email: z.string().email('有効なメールアドレスを入力してください').optional().or(z.literal('')),
+});
+
+type OrganizationFormData = z.infer<typeof organizationSchema>;
+
+interface Organization {
+  id: string;
+  name: string;
+  code: string;
+  taxId?: string;
+  address?: string;
+  phone?: string;
+  email?: string;
+  _count?: {
+    userOrganizations: number;
+    accounts: number;
+    journalEntries: number;
+  };
+}
+
+export default function OrganizationSettingsPage() {
+  const router = useRouter();
+  const { user, currentOrganization } = useAuth();
+  const [organization, setOrganization] = useState<Organization | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isFetching, setIsFetching] = useState(true);
+
+  const form = useForm<OrganizationFormData>({
+    resolver: zodResolver(organizationSchema),
+    defaultValues: {
+      name: '',
+      taxId: '',
+      address: '',
+      phone: '',
+      email: '',
+    },
+  });
+
+  useEffect(() => {
+    const fetchOrganization = async () => {
+      if (!currentOrganization) {
+        setIsFetching(false);
+        return;
+      }
+
+      try {
+        const response = await api.get<{ data: Organization }>('/organizations/current');
+        const org = response.data?.data;
+        if (!org) {
+          throw new Error('Failed to fetch organization');
+        }
+        setOrganization(org);
+        form.reset({
+          name: org.name || '',
+          taxId: org.taxId || '',
+          address: org.address || '',
+          phone: org.phone || '',
+          email: org.email || '',
+        });
+      } catch (error) {
+        console.error('Failed to fetch organization:', error);
+        toast.error('組織情報の取得に失敗しました');
+      } finally {
+        setIsFetching(false);
+      }
+    };
+
+    fetchOrganization();
+  }, [currentOrganization, form]);
+
+  const onSubmit = async (data: OrganizationFormData) => {
+    if (!organization) return;
+
+    setIsLoading(true);
+    try {
+      const response = await api.put<{ data: Organization }>(
+        `/organizations/${organization.id}`,
+        data
+      );
+      if (response.data?.data) {
+        setOrganization(response.data.data);
+      }
+      toast.success('組織情報を更新しました');
+    } catch (error) {
+      console.error('Failed to update organization:', error);
+      toast.error('組織情報の更新に失敗しました');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Check if current user is admin
+  const currentUserRole = user?.currentOrganization?.role;
+  const isAdmin = currentUserRole === 'ADMIN';
+
+  if (isFetching) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <Loader2 className="h-8 w-8 animate-spin" />
+      </div>
+    );
+  }
+
+  if (!organization) {
+    return (
+      <div className="p-8">
+        <p>組織が選択されていません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto py-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold">組織設定</h1>
+        <p className="mt-2 text-muted-foreground">組織の基本情報とメンバーを管理します</p>
+      </div>
+
+      <Tabs defaultValue="general" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="general">基本情報</TabsTrigger>
+          <TabsTrigger value="members">メンバー管理</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="general" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>組織情報</CardTitle>
+              <CardDescription>組織の基本情報を管理します</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                  <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                    <FormField
+                      control={form.control}
+                      name="name"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>組織名</FormLabel>
+                          <FormControl>
+                            <Input
+                              {...field}
+                              disabled={!isAdmin || isLoading}
+                              placeholder="株式会社サンプル"
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <div className="space-y-2">
+                      <FormLabel>組織コード</FormLabel>
+                      <Input value={organization.code} disabled />
+                      <p className="text-sm text-muted-foreground">組織コードは変更できません</p>
+                    </div>
+
+                    <FormField
+                      control={form.control}
+                      name="taxId"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>法人番号</FormLabel>
+                          <FormControl>
+                            <Input
+                              {...field}
+                              disabled={!isAdmin || isLoading}
+                              placeholder="1234567890123"
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="phone"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>電話番号</FormLabel>
+                          <FormControl>
+                            <Input
+                              {...field}
+                              disabled={!isAdmin || isLoading}
+                              placeholder="03-1234-5678"
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="email"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>メールアドレス</FormLabel>
+                          <FormControl>
+                            <Input
+                              {...field}
+                              disabled={!isAdmin || isLoading}
+                              type="email"
+                              placeholder="info@example.com"
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="address"
+                      render={({ field }) => (
+                        <FormItem className="md:col-span-2">
+                          <FormLabel>住所</FormLabel>
+                          <FormControl>
+                            <Input
+                              {...field}
+                              disabled={!isAdmin || isLoading}
+                              placeholder="東京都千代田区..."
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+
+                  {isAdmin && (
+                    <div className="flex justify-end">
+                      <Button type="submit" disabled={isLoading}>
+                        {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                        更新
+                      </Button>
+                    </div>
+                  )}
+                </form>
+              </Form>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>統計情報</CardTitle>
+              <CardDescription>組織の利用状況</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+                <div>
+                  <p className="text-sm text-muted-foreground">メンバー数</p>
+                  <p className="text-2xl font-bold">
+                    {organization._count?.userOrganizations || 0}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-sm text-muted-foreground">勘定科目数</p>
+                  <p className="text-2xl font-bold">{organization._count?.accounts || 0}</p>
+                </div>
+                <div>
+                  <p className="text-sm text-muted-foreground">仕訳数</p>
+                  <p className="text-2xl font-bold">{organization._count?.journalEntries || 0}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="members">
+          <Card>
+            <CardHeader>
+              <CardTitle>メンバー管理</CardTitle>
+              <CardDescription>組織のメンバーを管理します</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="flex justify-center">
+                <Button onClick={() => router.push('/dashboard/settings/organization/members')}>
+                  メンバー管理画面へ
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/settings/page.tsx
+++ b/apps/web/src/app/dashboard/settings/page.tsx
@@ -29,8 +29,16 @@ export default function SettingsPage() {
       title: '組織設定',
       icon: Building,
       items: [
-        { label: '組織情報', description: '組織名や住所の編集' },
-        { label: 'メンバー管理', description: 'ユーザーの招待と権限管理' },
+        {
+          label: '組織情報',
+          description: '組織名や住所の編集',
+          href: '/dashboard/settings/organization',
+        },
+        {
+          label: 'メンバー管理',
+          description: 'ユーザーの招待と権限管理',
+          href: '/dashboard/settings/organization/members',
+        },
       ],
     },
     {

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,226 @@
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />;
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuGroup({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />;
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = 'default',
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean;
+  variant?: 'default' | 'destructive';
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  );
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return <DropdownMenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />;
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  );
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn('px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn('bg-border -mx-1 my-1 h-px', className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSub({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  );
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,9 @@ importers:
       react-hot-toast:
         specifier: ^2.5.2
         version: 2.5.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -5112,6 +5115,12 @@ packages:
   socks@2.8.5:
     resolution: {integrity: sha512-iF+tNDQla22geJdTyJB1wM/qrX9DMRwWrciEPwWLPRWAUEM8sQiyxgckLxWT1f7+9VabJS0jTGGr4QgBuvi6Ww==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -11141,6 +11150,11 @@ snapshots:
     dependencies:
       ip-address: 9.0.5
       smart-buffer: 4.2.0
+
+  sonner@2.0.7(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## 概要

組織設定画面のUIは存在していましたが、組織情報の編集、メンバー管理、ロール管理などの機能が未実装でした。本PRではこれらの機能を完全に実装します。

Fixes #78

## 変更内容

### API実装
- ✅ GET `/api/v1/organizations/:id/members` - メンバー一覧取得
- ✅ PUT `/api/v1/organizations/:id/members/:userId` - メンバーロール更新
- ✅ 最後の管理者の保護機能を追加

### UI実装
- ✅ 組織設定ページ (`/dashboard/settings/organization`)
  - 組織情報編集フォーム
  - 統計情報表示（メンバー数、勘定科目数、仕訳数）
- ✅ メンバー管理ページ (`/dashboard/settings/organization/members`)
  - メンバー一覧テーブル
  - メンバー招待ダイアログ
  - ロール変更機能
  - メンバー削除確認ダイアログ

### ビジネスロジック
- ✅ 組織には最低1人のADMINが必要
- ✅ 最後のADMINは削除・ロール変更不可
- ✅ 自分自身の削除・ロール変更を防止
- ✅ 組織内のメンバーのみアクセス可能
- ✅ ADMIN権限によるアクセス制御

## テスト計画

### 手動テスト
- [ ] 組織情報の閲覧（全メンバー）
- [ ] 組織情報の編集（ADMINのみ）
- [ ] メンバー一覧の表示
- [ ] メンバーの招待（ADMINのみ）
- [ ] メンバーのロール変更（ADMINのみ）
- [ ] メンバーの削除（ADMINのみ）
- [ ] 最後のADMINの保護動作確認
- [ ] 自分自身の操作制限確認

### 技術的検証
- [ ] TypeScriptの型チェック通過
- [ ] ESLintエラーなし
- [ ] ビルド成功

## スクリーンショット

（後で追加予定）

## 今後の改善点

- メール送信機能は外部サービス（SendGrid、Amazon SES等）の選定と設定が必要
- 初期実装では招待リンクの生成までとし、メール送信は別タスクとして検討

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>