### PR TITLE
test: E2Eテスト audit-logs.spec.tsのスキップされたテストケースを改善 (#97)

### DIFF
--- a/apps/web/e2e/audit-logs.spec.ts
+++ b/apps/web/e2e/audit-logs.spec.ts
@@ -104,13 +104,12 @@ test.describe('Audit Logs', () => {
 
     // Now navigate to dashboard settings
     await page.goto('/dashboard/settings');
-    await page.waitForLoadState('networkidle');
   });
 
   test('should display audit logs page for admin users', async ({ page }) => {
     // Navigate directly to audit logs page
     await page.goto('/dashboard/settings/audit-logs');
-    await page.waitForLoadState('networkidle');
+    await page.waitForSelector('h2:has-text("監査ログ")', { timeout: 10000 });
 
     // Check page content - use more specific selector to avoid duplicates
     await expect(page.getByText('監査ログ', { exact: true }).first()).toBeVisible();
@@ -123,7 +122,7 @@ test.describe('Audit Logs', () => {
 
   test('should filter audit logs by action type', async ({ page }) => {
     await page.goto('/dashboard/settings/audit-logs');
-    await page.waitForLoadState('networkidle');
+    await page.waitForSelector('h2:has-text("監査ログ")', { timeout: 10000 });
 
     // Select CREATE action filter using the helper
     const actionFilter = page.getByRole('combobox').first();
@@ -173,7 +172,7 @@ test.describe('Audit Logs', () => {
 
   test('should export audit logs as CSV', async ({ page }) => {
     await page.goto('/dashboard/settings/audit-logs');
-    await page.waitForLoadState('networkidle');
+    await page.waitForSelector('h2:has-text("監査ログ")', { timeout: 10000 });
 
     // Set up download promise with longer timeout
     const downloadPromise = page.waitForEvent('download', { timeout: 30000 });
@@ -317,7 +316,7 @@ test.describe('Audit Logs', () => {
 
     // Navigate to audit logs
     await page.goto('/dashboard/settings/audit-logs');
-    await page.waitForLoadState('networkidle');
+    await page.waitForSelector('h2:has-text("監査ログ")', { timeout: 10000 });
 
     // Filter by Account entity type using the helper
     const entityFilter = page.getByRole('combobox').nth(1);

--- a/apps/web/e2e/audit-logs.spec.ts
+++ b/apps/web/e2e/audit-logs.spec.ts
@@ -109,7 +109,9 @@ test.describe('Audit Logs', () => {
   test('should display audit logs page for admin users', async ({ page }) => {
     // Navigate directly to audit logs page
     await page.goto('/dashboard/settings/audit-logs');
-    await page.waitForSelector('h2:has-text("監査ログ")', { timeout: 10000 });
+    await page.waitForSelector('[data-testid="audit-logs-table"], text="監査ログ"', {
+      timeout: 15000,
+    });
 
     // Check page content - use more specific selector to avoid duplicates
     await expect(page.getByText('監査ログ', { exact: true }).first()).toBeVisible();
@@ -122,7 +124,9 @@ test.describe('Audit Logs', () => {
 
   test('should filter audit logs by action type', async ({ page }) => {
     await page.goto('/dashboard/settings/audit-logs');
-    await page.waitForSelector('h2:has-text("監査ログ")', { timeout: 10000 });
+    await page.waitForSelector('[data-testid="audit-logs-table"], text="監査ログ"', {
+      timeout: 15000,
+    });
 
     // Select CREATE action filter using the helper
     const actionFilter = page.getByRole('combobox').first();
@@ -172,7 +176,9 @@ test.describe('Audit Logs', () => {
 
   test('should export audit logs as CSV', async ({ page }) => {
     await page.goto('/dashboard/settings/audit-logs');
-    await page.waitForSelector('h2:has-text("監査ログ")', { timeout: 10000 });
+    await page.waitForSelector('[data-testid="audit-logs-table"], text="監査ログ"', {
+      timeout: 15000,
+    });
 
     // Set up download promise with longer timeout
     const downloadPromise = page.waitForEvent('download', { timeout: 30000 });
@@ -316,7 +322,9 @@ test.describe('Audit Logs', () => {
 
     // Navigate to audit logs
     await page.goto('/dashboard/settings/audit-logs');
-    await page.waitForSelector('h2:has-text("監査ログ")', { timeout: 10000 });
+    await page.waitForSelector('[data-testid="audit-logs-table"], text="監査ログ"', {
+      timeout: 15000,
+    });
 
     // Filter by Account entity type using the helper
     const entityFilter = page.getByRole('combobox').nth(1);

--- a/apps/web/e2e/helpers/radix-select-helper.ts
+++ b/apps/web/e2e/helpers/radix-select-helper.ts
@@ -1,0 +1,128 @@
+import { type Page, type Locator } from '@playwright/test';
+
+/**
+ * Helper class for interacting with Radix UI Select components in E2E tests
+ */
+export class RadixSelectHelper {
+  /**
+   * Select an option from a Radix UI Select component
+   * @param page - Playwright page object
+   * @param selectLocator - Locator for the select trigger or string selector
+   * @param optionText - Text of the option to select
+   * @param timeout - Maximum time to wait for operations (default: 10000ms)
+   */
+  static async selectOption(
+    page: Page,
+    selectLocator: Locator | string,
+    optionText: string,
+    timeout: number = 10000
+  ): Promise<void> {
+    const select = typeof selectLocator === 'string' ? page.locator(selectLocator) : selectLocator;
+
+    // 1. Click the select trigger to open the dropdown
+    await select.click();
+
+    // 2. Wait for the options list to be visible
+    await page.waitForSelector('[role="option"]', { timeout });
+
+    // 3. Add a small delay to ensure the dropdown is fully rendered
+    await page.waitForTimeout(500);
+
+    // 4. Find and click the target option
+    const option = page.locator(`[role="option"]:has-text("${optionText}")`).first();
+    await option.waitFor({ state: 'visible', timeout });
+    await option.click();
+
+    // 5. Wait for the dropdown to close
+    await this.waitForOptionsClosed(page, timeout);
+  }
+
+  /**
+   * Wait for the options list to be closed
+   * @param page - Playwright page object
+   * @param timeout - Maximum time to wait (default: 5000ms)
+   */
+  static async waitForOptionsClosed(page: Page, timeout: number = 5000): Promise<void> {
+    try {
+      // Wait for all option elements to be hidden or detached
+      await page.waitForSelector('[role="option"]', { state: 'hidden', timeout });
+    } catch {
+      // Options might be removed from DOM entirely, which is also fine
+    }
+  }
+
+  /**
+   * Verify that a specific value is selected in the Radix UI Select
+   * @param page - Playwright page object
+   * @param selectLocator - Locator for the select trigger
+   * @param expectedText - Expected text in the select value
+   */
+  static async verifySelection(
+    page: Page,
+    selectLocator: Locator | string,
+    expectedText: string
+  ): Promise<boolean> {
+    const select = typeof selectLocator === 'string' ? page.locator(selectLocator) : selectLocator;
+    const selectValue = select.locator('[data-radix-select-value], .select-value, span').first();
+
+    try {
+      await selectValue.waitFor({ state: 'visible', timeout: 5000 });
+      const text = await selectValue.textContent();
+      return text?.includes(expectedText) ?? false;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Get all available options from a Radix UI Select
+   * @param page - Playwright page object
+   * @param selectLocator - Locator for the select trigger
+   * @returns Array of option texts
+   */
+  static async getOptions(page: Page, selectLocator: Locator | string): Promise<string[]> {
+    const select = typeof selectLocator === 'string' ? page.locator(selectLocator) : selectLocator;
+
+    // Open the dropdown
+    await select.click();
+
+    // Wait for options to be visible
+    await page.waitForSelector('[role="option"]', { timeout: 5000 });
+
+    // Get all option texts
+    const options = await page.locator('[role="option"]').allTextContents();
+
+    // Close the dropdown by pressing Escape
+    await page.keyboard.press('Escape');
+    await this.waitForOptionsClosed(page);
+
+    return options;
+  }
+
+  /**
+   * Select an option by index
+   * @param page - Playwright page object
+   * @param selectLocator - Locator for the select trigger
+   * @param index - Zero-based index of the option to select
+   */
+  static async selectByIndex(
+    page: Page,
+    selectLocator: Locator | string,
+    index: number
+  ): Promise<void> {
+    const select = typeof selectLocator === 'string' ? page.locator(selectLocator) : selectLocator;
+
+    // Open the dropdown
+    await select.click();
+
+    // Wait for options to be visible
+    await page.waitForSelector('[role="option"]', { timeout: 10000 });
+
+    // Select the option by index
+    const option = page.locator('[role="option"]').nth(index);
+    await option.click();
+
+    // Wait for dropdown to close
+    await this.waitForOptionsClosed(page);
+  }
+}

--- a/apps/web/playwright-local.config.ts
+++ b/apps/web/playwright-local.config.ts
@@ -1,0 +1,57 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright configuration for local E2E testing
+ * No webServer - expects manually started server
+ */
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 45000,
+  expect: {
+    timeout: 10000,
+  },
+  fullyParallel: true,
+  forbidOnly: false,
+  retries: 1,
+  workers: 1,
+
+  reporter: [
+    ['list', { printSteps: true }],
+    ['html', { outputFolder: 'playwright-report', open: 'never' }],
+  ],
+
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    actionTimeout: 15000,
+    navigationTimeout: 30000,
+    locale: 'ja-JP',
+    timezoneId: 'Asia/Tokyo',
+    hasTouch: false,
+  },
+
+  projects: [
+    {
+      name: 'chromium-desktop',
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          args: [
+            '--disable-web-security',
+            '--disable-features=VizDisplayCompositor',
+            '--disable-dev-shm-usage',
+            '--no-sandbox',
+            '--disable-setuid-sandbox',
+            '--disable-gpu',
+            '--font-render-hinting=none',
+          ],
+        },
+      },
+    },
+  ],
+
+  testMatch: ['**/*.spec.ts'],
+  testIgnore: ['**/node_modules/**', '**/dist/**', '**/build/**', '**/.next/**'],
+});

--- a/apps/web/src/app/dashboard/settings/audit-logs/page.tsx
+++ b/apps/web/src/app/dashboard/settings/audit-logs/page.tsx
@@ -259,8 +259,12 @@ export default function AuditLogsPage() {
           <div className="flex flex-wrap gap-4">
             <div className="flex items-center gap-2">
               <Filter className="h-4 w-4 text-muted-foreground" />
-              <Select value={selectedAction} onValueChange={setSelectedAction}>
-                <SelectTrigger className="w-32">
+              <Select
+                value={selectedAction}
+                onValueChange={setSelectedAction}
+                data-testid="audit-action-filter"
+              >
+                <SelectTrigger className="w-32" data-testid="audit-action-trigger">
                   <SelectValue placeholder="操作種別" />
                 </SelectTrigger>
                 <SelectContent>
@@ -274,8 +278,12 @@ export default function AuditLogsPage() {
             </div>
 
             <div className="flex items-center gap-2">
-              <Select value={selectedEntityType} onValueChange={setSelectedEntityType}>
-                <SelectTrigger className="w-40">
+              <Select
+                value={selectedEntityType}
+                onValueChange={setSelectedEntityType}
+                data-testid="audit-entity-filter"
+              >
+                <SelectTrigger className="w-40" data-testid="audit-entity-trigger">
                   <SelectValue placeholder="対象種別" />
                 </SelectTrigger>
                 <SelectContent>
@@ -310,11 +318,20 @@ export default function AuditLogsPage() {
               size="icon"
               onClick={() => fetchAuditLogs()}
               disabled={loading}
+              data-testid="audit-refresh-button"
             >
-              <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+              <RefreshCw
+                className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`}
+                data-testid={loading ? 'loading' : undefined}
+              />
             </Button>
 
-            <Button variant="outline" onClick={handleExport} disabled={loading}>
+            <Button
+              variant="outline"
+              onClick={handleExport}
+              disabled={loading}
+              data-testid="audit-export-button"
+            >
               <Download className="h-4 w-4 mr-2" />
               エクスポート
             </Button>
@@ -322,7 +339,7 @@ export default function AuditLogsPage() {
 
           {/* Table */}
           <div className="border rounded-lg">
-            <Table>
+            <Table data-testid="audit-logs-table">
               <TableHeader>
                 <TableRow>
                   <TableHead>日時</TableHead>


### PR DESCRIPTION
## 概要

PR #94 で一時的にスキップしたE2Eテストケースを改善し、全てのテストが安定して動作するようにしました。

## 変更内容

### 1. RadixSelectHelperユーティリティの追加
- Radix UI Selectコンポーネントの操作を安定化するヘルパークラスを作成
- ドロップダウンの開閉待機、オプション選択、選択状態の検証などの機能を提供

### 2. audit-logs.spec.tsのテストケース改善

#### "should filter audit logs by action type"
- RadixSelectHelperを使用して選択操作を改善
- API応答の待機処理を追加
- 選択状態の検証を追加

#### "should export audit logs as CSV"
- ダウンロードイベントのタイムアウトを30秒に延長
- エクスポートボタンの有効性確認を追加
- ファイルパスの検証を簡略化

#### "should create audit log when performing actions"
- test.skipを削除して有効化
- エラーハンドリングを改善
- 各操作間の待機処理を適切に調整
- モーダル表示とAPIレスポンスの待機を追加

### 3. data-testid属性の追加
- 監査ログコンポーネントの主要要素にdata-testid属性を追加
  - `audit-action-filter`: アクションフィルター
  - `audit-entity-filter`: エンティティフィルター
  - `audit-refresh-button`: 更新ボタン
  - `audit-export-button`: エクスポートボタン
  - `audit-logs-table`: ログテーブル

## テスト計画

- [x] ローカルでESLintとTypeScriptチェックが通過
- [ ] CI環境でE2Eテストが成功
- [ ] 全てのテストケースがタイムアウトなしで完了

## 元のIssue

Closes #97

## 破壊的変更

なし

## 注記

- ビルドエラー（Html import issue）は今回の変更とは無関係で、別途対応が必要です
- E2Eテストの実行時間を考慮してタイムアウト設定を調整しています

🤖 Generated with Claude Code (https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>