### PR TITLE
test: APIテストファイルの環境変数設定を修正 (#115)

### DIFF
--- a/apps/api/src/e2e/accounts.e2e.test.ts
+++ b/apps/api/src/e2e/accounts.e2e.test.ts
@@ -1,3 +1,6 @@
+// Setup test environment variables first
+import '../test-utils/env-setup';
+
 import { AccountType, UserRole } from '@prisma/client';
 import request from 'supertest';
 

--- a/apps/api/src/e2e/auth.e2e.test.ts
+++ b/apps/api/src/e2e/auth.e2e.test.ts
@@ -1,3 +1,6 @@
+// Setup test environment variables first
+import '../test-utils/env-setup';
+
 import { UserRole } from '@prisma/client';
 import request from 'supertest';
 

--- a/apps/api/src/e2e/journalEntries.e2e.test.ts
+++ b/apps/api/src/e2e/journalEntries.e2e.test.ts
@@ -1,3 +1,6 @@
+// Setup test environment variables first
+import '../test-utils/env-setup';
+
 import { AccountType, UserRole } from '@prisma/client';
 import request from 'supertest';
 

--- a/apps/api/src/e2e/reports.e2e.test.ts
+++ b/apps/api/src/e2e/reports.e2e.test.ts
@@ -1,3 +1,6 @@
+// Setup test environment variables first
+import '../test-utils/env-setup';
+
 import { AccountType, JournalStatus, UserRole } from '@prisma/client';
 import request from 'supertest';
 

--- a/apps/api/src/utils/__tests__/jwt.test.ts
+++ b/apps/api/src/utils/__tests__/jwt.test.ts
@@ -47,15 +47,22 @@ describe('JWT Utils', () => {
       expect(decodedRefresh.sub).toBe(userId);
     });
 
-    it('should throw error when JWT_SECRET is not set', () => {
+    it('should throw error when JWT_SECRET is not set in non-test environment', () => {
+      // Save original values
+      const originalSecret = process.env.JWT_SECRET;
+      const originalNodeEnv = process.env.NODE_ENV;
+
+      // Set NODE_ENV to production to test the error case
+      process.env.NODE_ENV = 'production';
       delete process.env.JWT_SECRET;
 
       expect(() => {
         generateTokens(userId, email, organizationId, role);
       }).toThrow('JWT_SECRET environment variable is required');
 
-      // Restore for other tests
-      process.env.JWT_SECRET = 'test-jwt-secret-with-sufficient-length-for-security-purposes';
+      // Restore original values
+      process.env.JWT_SECRET = originalSecret;
+      process.env.NODE_ENV = originalNodeEnv;
     });
   });
 


### PR DESCRIPTION
## 概要
Issue #115 で報告されたAPIテストファイルの環境変数設定問題を修正しました。

## 変更内容
- 🔧 E2Eテストファイル（4ファイル）にenv-setupのインポートを追加
- ✅ jwt.test.tsのテストケースを環境に応じた動作に修正
- 🎯 NODE_ENV=productionでのみJWT_SECRETエラーをチェックするように変更

## 修正したファイル
- `apps/api/src/e2e/auth.e2e.test.ts`
- `apps/api/src/e2e/accounts.e2e.test.ts`
- `apps/api/src/e2e/journalEntries.e2e.test.ts`
- `apps/api/src/e2e/reports.e2e.test.ts`
- `apps/api/src/utils/__tests__/jwt.test.ts`

## テスト計画
- [x] ローカルでAPIテストが全て通ることを確認
- [x] ESLintチェックが通ることを確認
- [x] TypeScriptの型チェックが通ることを確認
- [ ] CIでテストが通ることを確認

## 関連Issue
- Fixes #115

🤖 Generated with [Claude Code](https://claude.ai/code)