### PR TITLE
fix: CI warnings and turbo.json output configuration (#117)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -29,7 +29,7 @@
       "outputs": []
     },
     "test": {
-      "outputs": ["coverage/**"],
+      "outputs": [],
       "dependsOn": [],
       "env": ["NODE_ENV"]
     },


### PR DESCRIPTION
## 概要
CI実行時に発生している turbo.json の警告メッセージを解決します。

## 変更内容
- `test` タスクの `outputs` 設定を `["coverage/**"]` から `[]` に変更
- テストタスクはデフォルトではカバレッジファイルを生成しないため、空配列を設定

## 解決する警告
```
WARNING  no output files found for task @simple-bookkeeping/shared#test. Please check your `outputs` key in `turbo.json`
WARNING  no output files found for task @simple-bookkeeping/web#test. Please check your `outputs` key in `turbo.json`
```

## PostgreSQL locale警告について
CI環境でのPostgreSQL locale警告については以下の理由により今回は対応を見送りました：
- 実際の動作に影響がない
- 優先度が低い（Issueにも記載）
- PostgreSQLコンテナイメージの設定変更が必要で影響範囲が大きい

## テスト
- [x] `pnpm lint` - ✅ パス
- [x] `pnpm typecheck` - ✅ パス
- [x] `pnpm test` - ✅ パス
- [ ] CIチェック - 実行待ち

## 関連
- Fixes #117

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>