### PR TITLE
fix: Fix CI test failures in API controller tests (#141)

### DIFF
--- a/apps/api/src/controllers/__tests__/auditLog.controller.test.ts
+++ b/apps/api/src/controllers/__tests__/auditLog.controller.test.ts
@@ -33,7 +33,7 @@ describe('AuditLogController', () => {
         action: 'CREATE',
         entityType: 'JournalEntry',
         entityId: 'test-entity-1',
-        details: { description: 'Created journal entry' },
+        newValues: { description: 'Created journal entry' },
         ipAddress: '127.0.0.1',
       },
     });
@@ -45,7 +45,8 @@ describe('AuditLogController', () => {
         action: 'UPDATE',
         entityType: 'Account',
         entityId: 'test-entity-2',
-        details: { changes: { name: 'Updated name' } },
+        oldValues: { name: 'Original name' },
+        newValues: { name: 'Updated name' },
         ipAddress: '127.0.0.1',
       },
     });
@@ -100,8 +101,8 @@ describe('AuditLogController', () => {
         .get('/api/v1/audit-logs')
         .set('Authorization', `Bearer ${adminToken}`)
         .query({
-          from: today.toISOString().split('T')[0],
-          to: tomorrow.toISOString().split('T')[0],
+          startDate: today.toISOString(),
+          endDate: tomorrow.toISOString(),
         });
 
       expect(response.status).toBe(200);
@@ -148,7 +149,7 @@ describe('AuditLogController', () => {
 
       expect(response.status).toBe(200);
       expect(response.body.data.id).toBe(log?.id);
-      expect(response.body.data).toHaveProperty('details');
+      expect(response.body.data).toHaveProperty('newValues');
     });
 
     it('should return 404 for non-existent log', async () => {
@@ -252,7 +253,11 @@ describe('AuditLogController', () => {
       });
 
       expect(auditLog).not.toBeNull();
-      expect(auditLog?.details).toHaveProperty('description', 'Test Entry for Audit');
+      expect(auditLog?.newValues).toEqual(
+        expect.objectContaining({
+          description: 'Test Entry for Audit',
+        })
+      );
     });
 
     it('should create audit log on account update', async () => {

--- a/apps/api/src/test-utils/test-helpers.ts
+++ b/apps/api/src/test-utils/test-helpers.ts
@@ -13,6 +13,7 @@ export const cleanupTestData = async () => {
   // Delete in correct order to respect foreign key constraints
   await prisma.journalEntryLine.deleteMany({});
   await prisma.journalEntry.deleteMany({});
+  await prisma.auditLog.deleteMany({});
   await prisma.account.deleteMany({});
   await prisma.accountingPeriod.deleteMany({});
   await prisma.userOrganization.deleteMany({});


### PR DESCRIPTION
## Summary

This PR partially addresses the CI test failures discovered in Issue #141. The main fixes address TypeScript compilation errors and database cleanup order issues that were preventing tests from compiling and running.

## Changes Made

- Fixed TypeScript error in `auditLog.controller.test.ts` by replacing non-existent `details` field with correct `oldValues`/`newValues` fields matching the Prisma schema
- Fixed database cleanup order in `test-helpers.ts` by deleting `auditLog` entries before `user` entries to respect foreign key constraints  
- Fixed date filter query parameters in tests from `from/to` to `startDate/endDate` to match controller expectations

## Issue Context

This issue was discovered during PR #140 when multiple API controller tests were failing in CI. The failures include:
- TypeScript compilation errors (✅ FIXED)
- Foreign key constraint violations during test cleanup (✅ FIXED)
- Missing controller method implementations (⚠️ STILL FAILING)

## Current CI Status

### Passing ✅
- Lint
- Type Check  
- Build
- Vercel deployment

### Still Failing ❌
- Test job - All controller tests still fail due to missing implementations

## Root Cause Analysis

The controller tests were written with the expectation that all controller methods would be implemented, but many endpoints are not yet implemented. The tests are checking for:
- Specific HTTP status codes
- Response data structures
- Authorization checks
- CRUD operations

## Recommendation

To fully resolve Issue #141, we need to take one of these approaches:

1. **Implement all missing controller methods** (Recommended long-term)
   - Large scope but provides full functionality
   - Would require implementing ~50+ controller methods

2. **Update tests to skip unimplemented features** (Quick fix)
   - Mark unimplemented tests as `test.skip` or `test.todo`
   - Allows CI to pass while tracking what needs implementation

3. **Create stub implementations** (Middle ground)
   - Add minimal controller methods that return expected status codes
   - Tests pass but functionality is not complete

## Next Steps

This PR provides the foundation fixes (TypeScript and cleanup issues). To get CI fully passing, we need a follow-up PR that either:
- Implements the missing controller methods, OR
- Updates the tests to skip unimplemented features

## Related Issues

- Partially fixes #141
- Related to #139, #140

## Testing

```bash
# Run affected tests
NODE_ENV=test pnpm --filter @simple-bookkeeping/api test

# The following now compile but still have failing assertions:
# - organizations.controller.test.ts
# - accountingPeriods.controller.test.ts  
# - auth.controller.test.ts
# - reports.controller.test.ts
# - accounts.controller.test.ts
# - ledgers.controller.test.ts
# - auditLog.controller.test.ts
```