### PR TITLE
fix: improve test isolation by adding afterEach cleanup to all controller tests (#156)

### DIFF
--- a/apps/api/src/controllers/__tests__/accountingPeriods.controller.test.ts
+++ b/apps/api/src/controllers/__tests__/accountingPeriods.controller.test.ts
@@ -23,6 +23,10 @@ describe('AccountingPeriodsController', () => {
     testSetup = await createFullTestSetup();
   });
 
+  afterEach(async () => {
+    await cleanupTestData();
+  });
+
   afterAll(async () => {
     await cleanupTestData();
     await prisma.$disconnect();

--- a/apps/api/src/controllers/__tests__/accounts.controller.test.ts
+++ b/apps/api/src/controllers/__tests__/accounts.controller.test.ts
@@ -23,6 +23,10 @@ describe('AccountsController', () => {
     testSetup = await createFullTestSetup();
   });
 
+  afterEach(async () => {
+    await cleanupTestData();
+  });
+
   afterAll(async () => {
     await cleanupTestData();
     await prisma.$disconnect();

--- a/apps/api/src/controllers/__tests__/auditLog.controller.test.ts
+++ b/apps/api/src/controllers/__tests__/auditLog.controller.test.ts
@@ -52,6 +52,10 @@ describe('AuditLogController', () => {
     });
   });
 
+  afterEach(async () => {
+    await cleanupTestData();
+  });
+
   afterAll(async () => {
     await cleanupTestData();
     await prisma.$disconnect();

--- a/apps/api/src/controllers/__tests__/auth-organization.test.ts
+++ b/apps/api/src/controllers/__tests__/auth-organization.test.ts
@@ -72,11 +72,17 @@ describe('Organization-based Authentication', () => {
     });
   });
 
+  afterEach(async () => {
+    // Clean up any additional data created during tests
+    await prisma.auditLog.deleteMany({});
+  });
+
   afterAll(async () => {
     // Clean up test data
     await prisma.userOrganization.deleteMany({});
     await prisma.user.deleteMany({});
     await prisma.organization.deleteMany({});
+    await prisma.$disconnect();
   });
 
   describe('POST /api/v1/auth/login', () => {

--- a/apps/api/src/controllers/__tests__/auth.controller.test.ts
+++ b/apps/api/src/controllers/__tests__/auth.controller.test.ts
@@ -30,6 +30,10 @@ describe('AuthController', () => {
     });
   });
 
+  afterEach(async () => {
+    await cleanupTestData();
+  });
+
   afterAll(async () => {
     await cleanupTestData();
     await prisma.$disconnect();

--- a/apps/api/src/controllers/__tests__/journalEntries.controller.test.ts
+++ b/apps/api/src/controllers/__tests__/journalEntries.controller.test.ts
@@ -23,6 +23,10 @@ describe('JournalEntriesController', () => {
     testSetup = await createFullTestSetup();
   });
 
+  afterEach(async () => {
+    await cleanupTestData();
+  });
+
   afterAll(async () => {
     await cleanupTestData();
     await prisma.$disconnect();

--- a/apps/api/src/controllers/__tests__/ledgers.controller.test.ts
+++ b/apps/api/src/controllers/__tests__/ledgers.controller.test.ts
@@ -57,6 +57,10 @@ describe('LedgersController', () => {
     });
   });
 
+  afterEach(async () => {
+    await cleanupTestData();
+  });
+
   afterAll(async () => {
     await cleanupTestData();
     await prisma.$disconnect();

--- a/apps/api/src/controllers/__tests__/organizations.controller.test.ts
+++ b/apps/api/src/controllers/__tests__/organizations.controller.test.ts
@@ -51,6 +51,10 @@ describe('OrganizationsController', () => {
     viewerToken = generateTestToken(viewerUser.id, testOrg.id, UserRole.VIEWER);
   });
 
+  afterEach(async () => {
+    await cleanupTestData();
+  });
+
   afterAll(async () => {
     await cleanupTestData();
     await prisma.$disconnect();

--- a/apps/api/src/controllers/__tests__/reports.controller.test.ts
+++ b/apps/api/src/controllers/__tests__/reports.controller.test.ts
@@ -89,6 +89,10 @@ describe('ReportsController', () => {
     });
   });
 
+  afterEach(async () => {
+    await cleanupTestData();
+  });
+
   afterAll(async () => {
     await cleanupTestData();
     await prisma.$disconnect();


### PR DESCRIPTION
## Summary

This PR fixes failing API tests in the CI environment by improving test data isolation. The tests were passing locally but failing in CI due to incomplete cleanup between test runs.

## Changes

- Added `afterEach` cleanup hooks to all API controller test files
- Ensures test data is properly cleaned up between individual test runs
- Added `prisma.$disconnect()` to `afterAll` hooks for proper database connection cleanup
- Improved test isolation to prevent data leakage between tests

## Problem

As reported in Issue #156, multiple API controller tests were failing in CI with errors like:
- Audit log tests returning 500 errors instead of expected 404s  
- Test data from previous tests affecting subsequent test runs
- Database connection issues due to incomplete cleanup

## Solution

The root cause was insufficient test data cleanup. Tests were only cleaning up data in `beforeEach` but not after each test completed, leading to:
1. Data pollution between tests
2. Race conditions in CI environment
3. Database connection pool exhaustion

By adding `afterEach` cleanup to all test suites, we ensure each test starts and ends with a clean state.

## Test Plan

- [x] All API tests pass locally (`pnpm --filter @simple-bookkeeping/api test`)
- [x] Linting passes (`pnpm lint`)
- [x] TypeScript type checking passes (`pnpm typecheck`)
- [ ] CI tests pass (monitoring)

## Related

- Fixes #156
- Follow-up from PR #155

🤖 Generated with [Claude Code](https://claude.ai/code)