### PR TITLE
fix: exclude test-utils from production build to resolve Render deployment error (#174)

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -24,6 +24,7 @@
     "**/*.test.ts",
     "**/*.spec.ts",
     "src/**/__tests__/**",
-    "src/e2e/**"
+    "src/e2e/**",
+    "src/test-utils/**"
   ]
 }


### PR DESCRIPTION
## Summary

- Add `"src/test-utils/**"` to exclude array in `apps/api/tsconfig.json`
- Prevents test utility files from being included in production builds
- Resolves Render deployment error where test-utils imports dev dependencies

## Problem

Renderでのproductionビルドが失敗していました：
```
src/test-utils/test-helpers.ts(1,31): error TS2307: Cannot find module '@simple-bookkeeping/config' or its corresponding type declarations.
src/test-utils/test-helpers.ts(3,51): error TS2307: Cannot find module '@simple-bookkeeping/test-utils' or its corresponding type declarations.
```

## Solution

`apps/api/tsconfig.json`の`exclude`配列に`"src/test-utils/**"`を追加することで、テスト用ユーティリティファイルが本番ビルドに含まれないようにしました。

## Test plan

- [x] `pnpm --filter @simple-bookkeeping/api build` でビルドが成功することを確認
- [x] `pnpm --filter @simple-bookkeeping/api typecheck` で型チェックが通ることを確認  
- [x] `pnpm --filter @simple-bookkeeping/api test` でテストが正常に動作することを確認
- [ ] Renderでのデプロイメントが成功することを確認（CI/CD結果待ち）

## Files Changed

- `apps/api/tsconfig.json` - exclude設定に`src/test-utils/**`を追加

Closes #174

🤖 Generated with [Claude Code](https://claude.ai/code)