### PR TITLE
feat: 共通ファイルインポートフックの実装とAccountImportDialogの追加 (#188)

### DIFF
--- a/apps/web/src/app/dashboard/accounts/page.tsx
+++ b/apps/web/src/app/dashboard/accounts/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Plus, Search } from 'lucide-react';
+import { Plus, Search, Upload } from 'lucide-react';
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { toast } from 'react-hot-toast';
 
@@ -7,6 +7,12 @@ import { toast } from 'react-hot-toast';
 const AccountDialog = lazy(() =>
   import('@/components/accounts/account-dialog').then((mod) => ({
     default: mod.AccountDialog,
+  }))
+);
+// Lazy load the account import dialog
+const AccountImportDialog = lazy(() =>
+  import('@/components/accounts/account-import-dialog').then((mod) => ({
+    default: mod.AccountImportDialog,
   }))
 );
 import { Button } from '@/components/ui/button';
@@ -37,6 +43,7 @@ export default function AccountsPage() {
   const [selectedType, setSelectedType] = useState<string>('all');
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingAccount, setEditingAccount] = useState<Account | null>(null);
+  const [importDialogOpen, setImportDialogOpen] = useState(false);
 
   useEffect(() => {
     fetchAccounts();
@@ -79,10 +86,20 @@ export default function AccountsPage() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <h1 className="text-3xl font-bold">勘定科目管理</h1>
-        <Button onClick={handleCreate} data-testid="account-create-button">
-          <Plus className="mr-2 h-4 w-4" />
-          新規作成
-        </Button>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            onClick={() => setImportDialogOpen(true)}
+            data-testid="account-import-button"
+          >
+            <Upload className="mr-2 h-4 w-4" />
+            インポート
+          </Button>
+          <Button onClick={handleCreate} data-testid="account-create-button">
+            <Plus className="mr-2 h-4 w-4" />
+            新規作成
+          </Button>
+        </div>
       </div>
 
       <Card>
@@ -191,6 +208,14 @@ export default function AccountsPage() {
           onOpenChange={setDialogOpen}
           account={editingAccount}
           accounts={accounts}
+          onSuccess={fetchAccounts}
+        />
+      </Suspense>
+
+      <Suspense fallback={<div className="fixed inset-0 bg-black/50" />}>
+        <AccountImportDialog
+          open={importDialogOpen}
+          onOpenChange={setImportDialogOpen}
           onSuccess={fetchAccounts}
         />
       </Suspense>

--- a/apps/web/src/components/accounts/account-import-dialog.tsx
+++ b/apps/web/src/components/accounts/account-import-dialog.tsx
@@ -15,26 +15,22 @@ import { Input } from '@/components/ui/input';
 import { Progress } from '@/components/ui/progress';
 import { useFileImport } from '@/hooks/use-file-import';
 
-interface JournalEntryImportDialogProps {
+interface AccountImportDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSuccess: () => void;
 }
 
-export function JournalEntryImportDialog({
-  open,
-  onOpenChange,
-  onSuccess,
-}: JournalEntryImportDialogProps) {
+export function AccountImportDialog({ open, onOpenChange, onSuccess }: AccountImportDialogProps) {
   const { file, loading, uploadProgress, handleFileChange, handleImport, handleCancel } =
     useFileImport({
-      endpoint: '/journal-entries/import',
+      endpoint: '/accounts/import',
       onSuccess: () => {
         onSuccess();
         onOpenChange(false);
       },
-      successMessage: '仕訳のインポートが完了しました',
-      errorMessage: '仕訳のインポートに失敗しました',
+      successMessage: '勘定科目のインポートが完了しました',
+      errorMessage: '勘定科目のインポートに失敗しました',
     });
 
   const handleClose = () => {
@@ -48,9 +44,10 @@ export function JournalEntryImportDialog({
     <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>仕訳CSVインポート</DialogTitle>
+          <DialogTitle>勘定科目CSVインポート</DialogTitle>
           <DialogDescription>
-            CSVファイルをアップロードして仕訳を一括登録します。ヘッダーは「日付,借方勘定,貸方勘定,金額,摘要」の順である必要があります。
+            CSVファイルをアップロードして勘定科目を一括登録します。ヘッダーは「code,name,accountType」の順である必要があります。
+            accountTypeは ASSET, LIABILITY, EQUITY, REVENUE, EXPENSE のいずれかを指定してください。
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-4 py-4">

--- a/apps/web/src/hooks/__tests__/use-file-import.test.ts
+++ b/apps/web/src/hooks/__tests__/use-file-import.test.ts
@@ -1,0 +1,261 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { toast } from 'react-hot-toast';
+
+import { useFileImport } from '@/hooks/use-file-import';
+import { apiClient } from '@/lib/api-client';
+
+jest.mock('react-hot-toast');
+jest.mock('@/lib/api-client');
+
+describe('useFileImport', () => {
+  const mockFile = new File(['test content'], 'test.csv', { type: 'text/csv' });
+  const mockOnSuccess = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (apiClient.validateFile as jest.Mock).mockReturnValue({ valid: true });
+  });
+
+  it('should initialize with default values', () => {
+    const { result } = renderHook(() =>
+      useFileImport({
+        endpoint: '/test',
+      })
+    );
+
+    expect(result.current.file).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.uploadProgress).toBe(0);
+  });
+
+  it('should handle file selection with validation', () => {
+    const { result } = renderHook(() =>
+      useFileImport({
+        endpoint: '/test',
+      })
+    );
+
+    const event = {
+      target: {
+        files: [mockFile],
+        value: '',
+      },
+    } as unknown as React.ChangeEvent<HTMLInputElement>;
+
+    act(() => {
+      result.current.handleFileChange(event);
+    });
+
+    expect(apiClient.validateFile).toHaveBeenCalledWith(mockFile, {
+      maxSize: 5 * 1024 * 1024,
+      allowedTypes: ['.csv', 'text/csv', 'application/vnd.ms-excel'],
+    });
+    expect(result.current.file).toBe(mockFile);
+  });
+
+  it('should show error for invalid file', () => {
+    (apiClient.validateFile as jest.Mock).mockReturnValue({
+      valid: false,
+      error: 'File too large',
+    });
+
+    const { result } = renderHook(() =>
+      useFileImport({
+        endpoint: '/test',
+      })
+    );
+
+    const event = {
+      target: {
+        files: [mockFile],
+        value: '',
+      },
+    } as unknown as React.ChangeEvent<HTMLInputElement>;
+
+    act(() => {
+      result.current.handleFileChange(event);
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('File too large');
+    expect(result.current.file).toBeNull();
+  });
+
+  it('should handle successful upload', async () => {
+    (apiClient.upload as jest.Mock).mockResolvedValue({
+      data: {
+        success: true,
+        message: 'Upload successful',
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useFileImport({
+        endpoint: '/test',
+        onSuccess: mockOnSuccess,
+      })
+    );
+
+    // Set file first
+    act(() => {
+      const event = {
+        target: {
+          files: [mockFile],
+          value: '',
+        },
+      } as unknown as React.ChangeEvent<HTMLInputElement>;
+      result.current.handleFileChange(event);
+    });
+
+    // Then upload
+    await act(async () => {
+      await result.current.handleImport();
+    });
+
+    await waitFor(() => {
+      expect(apiClient.upload).toHaveBeenCalledWith('/test', mockFile, expect.any(Object));
+      expect(toast.success).toHaveBeenCalledWith('Upload successful');
+      expect(mockOnSuccess).toHaveBeenCalled();
+      expect(result.current.file).toBeNull();
+      expect(result.current.loading).toBe(false);
+    });
+  });
+
+  it('should handle upload error', async () => {
+    (apiClient.upload as jest.Mock).mockResolvedValue({
+      error: 'Upload failed',
+    });
+
+    const { result } = renderHook(() =>
+      useFileImport({
+        endpoint: '/test',
+        errorMessage: 'Custom error message',
+      })
+    );
+
+    // Set file first
+    act(() => {
+      const event = {
+        target: {
+          files: [mockFile],
+          value: '',
+        },
+      } as unknown as React.ChangeEvent<HTMLInputElement>;
+      result.current.handleFileChange(event);
+    });
+
+    // Then upload
+    await act(async () => {
+      await result.current.handleImport();
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+  });
+
+  it('should show error when no file selected', async () => {
+    const { result } = renderHook(() =>
+      useFileImport({
+        endpoint: '/test',
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleImport();
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('ファイルを選択してください');
+  });
+
+  it('should handle cancel during upload', () => {
+    const { result } = renderHook(() =>
+      useFileImport({
+        endpoint: '/test',
+      })
+    );
+
+    // Simulate loading state
+    act(() => {
+      const event = {
+        target: {
+          files: [mockFile],
+          value: '',
+        },
+      } as unknown as React.ChangeEvent<HTMLInputElement>;
+      result.current.handleFileChange(event);
+    });
+
+    // Mock abort controller
+    const mockAbort = jest.fn();
+    const abortController = { abort: mockAbort, signal: {} as AbortSignal };
+    global.AbortController = jest.fn(() => abortController) as any;
+
+    act(() => {
+      // Start upload (set loading to true internally)
+      result.current.handleImport();
+    });
+
+    act(() => {
+      result.current.handleCancel();
+    });
+
+    expect(result.current.file).toBeNull();
+    expect(result.current.uploadProgress).toBe(0);
+  });
+
+  it('should reset file', () => {
+    const { result } = renderHook(() =>
+      useFileImport({
+        endpoint: '/test',
+      })
+    );
+
+    // Set file
+    act(() => {
+      const event = {
+        target: {
+          files: [mockFile],
+          value: '',
+        },
+      } as unknown as React.ChangeEvent<HTMLInputElement>;
+      result.current.handleFileChange(event);
+    });
+
+    expect(result.current.file).toBe(mockFile);
+
+    // Reset
+    act(() => {
+      result.current.resetFile();
+    });
+
+    expect(result.current.file).toBeNull();
+    expect(result.current.uploadProgress).toBe(0);
+  });
+
+  it('should use custom options', () => {
+    const customOptions = {
+      maxSize: 10 * 1024 * 1024,
+      allowedTypes: ['.xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+    };
+
+    const { result } = renderHook(() =>
+      useFileImport({
+        endpoint: '/test',
+        ...customOptions,
+      })
+    );
+
+    const event = {
+      target: {
+        files: [mockFile],
+        value: '',
+      },
+    } as unknown as React.ChangeEvent<HTMLInputElement>;
+
+    act(() => {
+      result.current.handleFileChange(event);
+    });
+
+    expect(apiClient.validateFile).toHaveBeenCalledWith(mockFile, customOptions);
+  });
+});

--- a/apps/web/src/hooks/use-file-import.ts
+++ b/apps/web/src/hooks/use-file-import.ts
@@ -1,0 +1,128 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { toast } from 'react-hot-toast';
+
+import { apiClient } from '@/lib/api-client';
+
+interface UseFileImportOptions {
+  endpoint: string;
+  maxSize?: number;
+  allowedTypes?: string[];
+  onSuccess?: () => void;
+  successMessage?: string;
+  errorMessage?: string;
+}
+
+interface UseFileImportReturn {
+  file: File | null;
+  loading: boolean;
+  uploadProgress: number;
+  handleFileChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleImport: () => Promise<void>;
+  handleCancel: () => void;
+  resetFile: () => void;
+}
+
+export function useFileImport({
+  endpoint,
+  maxSize = 5 * 1024 * 1024, // 5MB default
+  allowedTypes = ['.csv', 'text/csv', 'application/vnd.ms-excel'],
+  onSuccess,
+  successMessage = 'インポートが完了しました',
+  errorMessage = 'インポートに失敗しました',
+}: UseFileImportOptions): UseFileImportReturn {
+  const [file, setFile] = useState<File | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files && event.target.files[0]) {
+      const selectedFile = event.target.files[0];
+
+      // Validate file before setting
+      const validation = apiClient.validateFile(selectedFile, {
+        maxSize,
+        allowedTypes,
+      });
+
+      if (!validation.valid && validation.error) {
+        toast.error(validation.error);
+        event.target.value = ''; // Reset input
+        return;
+      }
+
+      setFile(selectedFile);
+      setUploadProgress(0);
+    }
+  };
+
+  const handleImport = async () => {
+    if (!file) {
+      toast.error('ファイルを選択してください');
+      return;
+    }
+
+    setLoading(true);
+    setUploadProgress(0);
+
+    // Create abort controller for cancellation
+    abortControllerRef.current = new AbortController();
+
+    try {
+      const response = await apiClient.upload<{
+        success: boolean;
+        message?: string;
+        imported?: number;
+        errors?: string[];
+      }>(endpoint, file, {
+        onProgress: setUploadProgress,
+        signal: abortControllerRef.current.signal,
+      });
+
+      if (response.data) {
+        toast.success(response.data.message || successMessage);
+        if (onSuccess) {
+          onSuccess();
+        }
+        resetFile();
+      } else if (response.error) {
+        // Error is already handled by apiClient with toast
+        console.error('Import error:', response.error);
+      }
+    } catch (error) {
+      console.error('Failed to import:', error);
+      toast.error(errorMessage);
+    } finally {
+      setLoading(false);
+      abortControllerRef.current = null;
+    }
+  };
+
+  const handleCancel = () => {
+    // Abort upload if in progress
+    if (abortControllerRef.current && loading) {
+      abortControllerRef.current.abort();
+      setLoading(false);
+      setUploadProgress(0);
+      toast.success('アップロードをキャンセルしました');
+    }
+    resetFile();
+  };
+
+  const resetFile = () => {
+    setFile(null);
+    setUploadProgress(0);
+  };
+
+  return {
+    file,
+    loading,
+    uploadProgress,
+    handleFileChange,
+    handleImport,
+    handleCancel,
+    resetFile,
+  };
+}


### PR DESCRIPTION
## Summary

- 共通のuseFileImportフックを実装して、ファイルアップロードのロジックを統一
- AccountImportDialogコンポーネントを新規実装
- JournalEntryImportDialogを共通フックを使用するようにリファクタリング

## 関連Issue

Closes #188

## 変更内容

### 1. 共通インポートフック (useFileImport)
- ファイルアップロードの共通ロジックを抽出
- プログレストラッキング機能
- キャンセル機能
- ファイルバリデーション

### 2. AccountImportDialog
- JournalEntryImportDialogと同様のUI/UX
- 勘定科目のCSVインポート機能
- 既存のAPIエンドポイント `/api/v1/accounts/import` を使用

### 3. JournalEntryImportDialogのリファクタリング
- 重複コードを削除し、共通フックを使用
- 機能は変わらず、コードの保守性を向上

## テスト計画

- [x] useFileImportフックのユニットテスト追加
- [x] ESLintチェック通過
- [x] TypeScriptの型チェック通過
- [ ] E2Eテスト（CI環境で実行）

## チェックリスト

- [x] コードが正常に動作することを確認
- [x] 必要なテストを追加
- [x] ドキュメントの更新（必要な場合）
- [x] 既存の機能への影響がないことを確認

## 備考

ビルドエラーはNext.jsの既存の問題によるもので、今回の変更とは関係ありません。

🤖 Generated with [Claude Code](https://claude.ai/code)