### PR TITLE
feat: ファイルインポートにドラッグ&ドロップ機能を実装 (#190)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -51,6 +51,7 @@
     "next": "15.3.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-dropzone": "^14.3.8",
     "react-hook-form": "^7.62.0",
     "react-hot-toast": "^2.5.2",
     "sonner": "^2.0.7",

--- a/apps/web/src/components/accounts/account-import-dialog.tsx
+++ b/apps/web/src/components/accounts/account-import-dialog.tsx
@@ -11,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { FileDropzone } from '@/components/ui/file-dropzone';
 import { Input } from '@/components/ui/input';
 import { Progress } from '@/components/ui/progress';
 import { useFileImport } from '@/hooks/use-file-import';
@@ -22,16 +23,23 @@ interface AccountImportDialogProps {
 }
 
 export function AccountImportDialog({ open, onOpenChange, onSuccess }: AccountImportDialogProps) {
-  const { file, loading, uploadProgress, handleFileChange, handleImport, handleCancel } =
-    useFileImport({
-      endpoint: '/accounts/import',
-      onSuccess: () => {
-        onSuccess();
-        onOpenChange(false);
-      },
-      successMessage: '勘定科目のインポートが完了しました',
-      errorMessage: '勘定科目のインポートに失敗しました',
-    });
+  const {
+    file,
+    loading,
+    uploadProgress,
+    handleFileChange,
+    handleDrop,
+    handleImport,
+    handleCancel,
+  } = useFileImport({
+    endpoint: '/accounts/import',
+    onSuccess: () => {
+      onSuccess();
+      onOpenChange(false);
+    },
+    successMessage: '勘定科目のインポートが完了しました',
+    errorMessage: '勘定科目のインポートに失敗しました',
+  });
 
   const handleClose = () => {
     if (loading) {
@@ -51,18 +59,23 @@ export function AccountImportDialog({ open, onOpenChange, onSuccess }: AccountIm
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-4 py-4">
+          <FileDropzone onDrop={handleDrop} disabled={loading} file={file} />
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <span className="w-full border-t" />
+            </div>
+            <div className="relative flex justify-center text-xs uppercase">
+              <span className="bg-background px-2 text-muted-foreground">または</span>
+            </div>
+          </div>
           <div className="space-y-2">
             <Input
               type="file"
               accept=".csv,text/csv,application/vnd.ms-excel"
               onChange={handleFileChange}
               disabled={loading}
+              className="cursor-pointer"
             />
-            {file && (
-              <div className="text-sm text-muted-foreground">
-                選択されたファイル: {file.name} ({(file.size / 1024).toFixed(1)} KB)
-              </div>
-            )}
           </div>
           {loading && uploadProgress > 0 && (
             <div className="space-y-2">

--- a/apps/web/src/components/journal-entries/journal-entry-import-dialog.tsx
+++ b/apps/web/src/components/journal-entries/journal-entry-import-dialog.tsx
@@ -11,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { FileDropzone } from '@/components/ui/file-dropzone';
 import { Input } from '@/components/ui/input';
 import { Progress } from '@/components/ui/progress';
 import { useFileImport } from '@/hooks/use-file-import';
@@ -26,16 +27,23 @@ export function JournalEntryImportDialog({
   onOpenChange,
   onSuccess,
 }: JournalEntryImportDialogProps) {
-  const { file, loading, uploadProgress, handleFileChange, handleImport, handleCancel } =
-    useFileImport({
-      endpoint: '/journal-entries/import',
-      onSuccess: () => {
-        onSuccess();
-        onOpenChange(false);
-      },
-      successMessage: '仕訳のインポートが完了しました',
-      errorMessage: '仕訳のインポートに失敗しました',
-    });
+  const {
+    file,
+    loading,
+    uploadProgress,
+    handleFileChange,
+    handleDrop,
+    handleImport,
+    handleCancel,
+  } = useFileImport({
+    endpoint: '/journal-entries/import',
+    onSuccess: () => {
+      onSuccess();
+      onOpenChange(false);
+    },
+    successMessage: '仕訳のインポートが完了しました',
+    errorMessage: '仕訳のインポートに失敗しました',
+  });
 
   const handleClose = () => {
     if (loading) {
@@ -54,18 +62,23 @@ export function JournalEntryImportDialog({
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-4 py-4">
+          <FileDropzone onDrop={handleDrop} disabled={loading} file={file} />
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <span className="w-full border-t" />
+            </div>
+            <div className="relative flex justify-center text-xs uppercase">
+              <span className="bg-background px-2 text-muted-foreground">または</span>
+            </div>
+          </div>
           <div className="space-y-2">
             <Input
               type="file"
               accept=".csv,text/csv,application/vnd.ms-excel"
               onChange={handleFileChange}
               disabled={loading}
+              className="cursor-pointer"
             />
-            {file && (
-              <div className="text-sm text-muted-foreground">
-                選択されたファイル: {file.name} ({(file.size / 1024).toFixed(1)} KB)
-              </div>
-            )}
           </div>
           {loading && uploadProgress > 0 && (
             <div className="space-y-2">

--- a/apps/web/src/components/ui/__tests__/file-dropzone.test.tsx
+++ b/apps/web/src/components/ui/__tests__/file-dropzone.test.tsx
@@ -1,0 +1,135 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { FileDropzone } from '../file-dropzone';
+
+describe('FileDropzone', () => {
+  const mockOnDrop = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render dropzone with default text', () => {
+    render(<FileDropzone onDrop={mockOnDrop} />);
+
+    expect(
+      screen.getByText('ファイルをドラッグ&ドロップするか、クリックして選択')
+    ).toBeInTheDocument();
+    expect(screen.getByText('CSV形式のファイル（最大5MB）')).toBeInTheDocument();
+  });
+
+  it('should display selected file name', () => {
+    const file = new File(['test content'], 'test.csv', { type: 'text/csv' });
+    render(<FileDropzone onDrop={mockOnDrop} file={file} />);
+
+    expect(screen.getByText(/選択中: test.csv/)).toBeInTheDocument();
+  });
+
+  it('should be disabled when disabled prop is true', () => {
+    const { container } = render(<FileDropzone onDrop={mockOnDrop} disabled />);
+    const dropzone = container.firstChild as HTMLElement;
+
+    expect(dropzone).toHaveClass('opacity-50', 'cursor-not-allowed');
+  });
+
+  it('should call onDrop when file is dropped', async () => {
+    const file = new File(['test content'], 'test.csv', { type: 'text/csv' });
+    const { container } = render(<FileDropzone onDrop={mockOnDrop} />);
+    const dropzone = container.firstChild as HTMLElement;
+
+    // Simulate file drop
+    const dataTransfer = {
+      files: [file],
+      items: [
+        {
+          kind: 'file',
+          type: 'text/csv',
+          getAsFile: () => file,
+        },
+      ],
+      types: ['Files'],
+    };
+
+    await act(async () => {
+      fireEvent.dragEnter(dropzone, { dataTransfer });
+      fireEvent.dragOver(dropzone, { dataTransfer });
+      fireEvent.drop(dropzone, { dataTransfer });
+    });
+
+    // Check if onDrop was called with the correct files
+    await waitFor(() => {
+      expect(mockOnDrop).toHaveBeenCalledTimes(1);
+      expect(mockOnDrop).toHaveBeenCalledWith([file]);
+    });
+  });
+
+  it('should show drag active state when dragging over', async () => {
+    const { container } = render(<FileDropzone onDrop={mockOnDrop} />);
+    const dropzone = container.firstChild as HTMLElement;
+
+    const dataTransfer = {
+      files: [],
+      items: [
+        {
+          kind: 'file',
+          type: 'text/csv',
+        },
+      ],
+      types: ['Files'],
+    };
+
+    await act(async () => {
+      fireEvent.dragEnter(dropzone, { dataTransfer });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('ファイルをドロップしてください')).toBeInTheDocument();
+    });
+  });
+
+  it('should show reject state for invalid file types', async () => {
+    const { container } = render(<FileDropzone onDrop={mockOnDrop} />);
+    const dropzone = container.firstChild as HTMLElement;
+
+    const dataTransfer = {
+      files: [],
+      items: [
+        {
+          kind: 'file',
+          type: 'image/png',
+        },
+      ],
+      types: ['Files'],
+    };
+
+    await act(async () => {
+      fireEvent.dragEnter(dropzone, { dataTransfer });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('このファイルは対応していません')).toBeInTheDocument();
+    });
+  });
+
+  it('should accept custom file types', () => {
+    const customAccept = {
+      'application/pdf': ['.pdf'],
+    };
+
+    render(<FileDropzone onDrop={mockOnDrop} accept={customAccept} />);
+
+    // Component should render without errors
+    expect(
+      screen.getByText('ファイルをドラッグ&ドロップするか、クリックして選択')
+    ).toBeInTheDocument();
+  });
+
+  it('should respect custom max size', () => {
+    const customMaxSize = 10 * 1024 * 1024; // 10MB
+
+    render(<FileDropzone onDrop={mockOnDrop} maxSize={customMaxSize} />);
+
+    // Component should render without errors with custom max size
+    expect(screen.getByText('CSV形式のファイル（最大5MB）')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ui/file-dropzone.tsx
+++ b/apps/web/src/components/ui/file-dropzone.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { CloudUpload } from 'lucide-react';
+import { useCallback } from 'react';
+import { useDropzone } from 'react-dropzone';
+
+import { cn } from '@/lib/utils';
+
+interface FileDropzoneProps {
+  onDrop: (files: File[]) => void;
+  accept?: Record<string, string[]>;
+  maxSize?: number;
+  disabled?: boolean;
+  file?: File | null;
+  className?: string;
+}
+
+export function FileDropzone({
+  onDrop,
+  accept = {
+    'text/csv': ['.csv'],
+    'application/vnd.ms-excel': ['.csv'],
+  },
+  maxSize = 5 * 1024 * 1024, // 5MB
+  disabled = false,
+  file,
+  className,
+}: FileDropzoneProps) {
+  const handleDrop = useCallback(
+    (acceptedFiles: File[]) => {
+      if (acceptedFiles.length > 0) {
+        onDrop(acceptedFiles);
+      }
+    },
+    [onDrop]
+  );
+
+  const { getRootProps, getInputProps, isDragActive, isDragReject } = useDropzone({
+    onDrop: handleDrop,
+    accept,
+    maxSize,
+    disabled,
+    multiple: false,
+  });
+
+  return (
+    <div
+      {...getRootProps()}
+      className={cn(
+        'relative rounded-lg border-2 border-dashed p-6 text-center cursor-pointer transition-colors',
+        isDragActive && !isDragReject && 'border-primary bg-primary/5',
+        isDragReject && 'border-destructive bg-destructive/5',
+        disabled && 'opacity-50 cursor-not-allowed',
+        !isDragActive && !isDragReject && 'border-muted-foreground/25 hover:border-primary/50',
+        className
+      )}
+    >
+      <input {...getInputProps()} />
+      <div className="flex flex-col items-center justify-center gap-2">
+        <CloudUpload
+          className={cn(
+            'h-8 w-8',
+            isDragActive && !isDragReject && 'text-primary',
+            isDragReject && 'text-destructive',
+            !isDragActive && !isDragReject && 'text-muted-foreground'
+          )}
+        />
+        {isDragActive && !isDragReject && (
+          <p className="text-sm text-primary">ファイルをドロップしてください</p>
+        )}
+        {isDragReject && <p className="text-sm text-destructive">このファイルは対応していません</p>}
+        {!isDragActive && (
+          <>
+            <p className="text-sm text-muted-foreground">
+              ファイルをドラッグ&ドロップするか、クリックして選択
+            </p>
+            <p className="text-xs text-muted-foreground">CSV形式のファイル（最大5MB）</p>
+            {file && (
+              <p className="mt-2 text-sm font-medium">
+                選択中: {file.name} ({(file.size / 1024).toFixed(1)} KB)
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,6 +321,9 @@ importers:
       react-dom:
         specifier: ^19.1.1
         version: 19.1.1(react@19.1.1)
+      react-dropzone:
+        specifier: ^14.3.8
+        version: 14.3.8(react@19.1.1)
       react-hook-form:
         specifier: ^7.62.0
         version: 7.62.0(react@19.1.1)
@@ -2595,6 +2598,10 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  attr-accept@2.2.5:
+    resolution: {integrity: sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==}
+    engines: {node: '>=4'}
+
   autoprefixer@10.4.21:
     resolution: {integrity: sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3540,6 +3547,10 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  file-selector@2.1.2:
+    resolution: {integrity: sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==}
+    engines: {node: '>= 12'}
 
   filelist@1.0.4:
     resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
@@ -5049,6 +5060,12 @@ packages:
     resolution: {integrity: sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==}
     peerDependencies:
       react: ^19.1.1
+
+  react-dropzone@14.3.8:
+    resolution: {integrity: sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug==}
+    engines: {node: '>= 10.13'}
+    peerDependencies:
+      react: '>= 16.8 || 18.0.0'
 
   react-hook-form@7.62.0:
     resolution: {integrity: sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==}
@@ -8254,6 +8271,8 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  attr-accept@2.2.5: {}
+
   autoprefixer@10.4.21(postcss@8.5.6):
     dependencies:
       browserslist: 4.25.1
@@ -9440,6 +9459,10 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  file-selector@2.1.2:
+    dependencies:
+      tslib: 2.8.1
 
   filelist@1.0.4:
     dependencies:
@@ -11262,6 +11285,13 @@ snapshots:
     dependencies:
       react: 19.1.1
       scheduler: 0.26.0
+
+  react-dropzone@14.3.8(react@19.1.1):
+    dependencies:
+      attr-accept: 2.2.5
+      file-selector: 2.1.2
+      prop-types: 15.8.1
+      react: 19.1.1
 
   react-hook-form@7.62.0(react@19.1.1):
     dependencies:


### PR DESCRIPTION
## 概要
Issue #190 の一部実装として、ファイルインポート機能にドラッグ&ドロップ対応を追加しました。

## 変更内容
### 🎯 実装機能
- ✅ ドラッグ&ドロップによるファイル選択
- ✅ 視覚的なフィードバック（ドラッグ中の状態表示）
- ✅ ファイルタイプ・サイズの検証
- ✅ 既存のファイル選択機能との併用

### 📝 技術的詳細
- **react-dropzone** ライブラリを使用
- **FileDropzone** コンポーネントを新規作成
- **useFileImport** フックを拡張
- AccountImportDialog と JournalEntryImportDialog を更新

### 🎨 UI/UX改善
- ドラッグ状態の視覚的フィードバック
  - 通常状態: グレーの破線枠
  - ドラッグ中: 青色の枠とメッセージ
  - 拒否状態: 赤色の枠とエラーメッセージ
- ファイル選択後の情報表示（ファイル名、サイズ）
- 「または」セパレーターで選択方法を明確に分離

## テスト
- [x] FileDropzone コンポーネントの単体テスト
- [x] ESLint チェック
- [x] TypeScript 型チェック

## 関連 Issue
Closes #190 (部分的に)

## 今後の作業
Issue #190 に記載されている以下の機能は別PRで実装予定：
- [ ] バッチ処理の進捗表示
- [ ] インポート履歴機能

## スクリーンショット
（デモ環境でのテスト後に追加予定）

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>