### PR TITLE
fix: Docker環境でのE2Eテスト失敗を修正 (#270)

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -104,7 +104,7 @@ jobs:
             -e DEBUG=${{ github.event.inputs.debug || 'false' }} \
             -e TEST_RETRIES=2 \
             -e TEST_WORKERS=2 \
-            -e PLAYWRIGHT_CONFIG=playwright.config.ci.ts \
+            -e PLAYWRIGHT_ARGS="--config playwright.config.ci.ts" \
             playwright || TEST_EXIT_CODE=$?
 
           # Export test exit code

--- a/Dockerfile.playwright
+++ b/Dockerfile.playwright
@@ -165,7 +165,17 @@ export PLAYWRIGHT_HTML_REPORT=/app/playwright-report
 export PLAYWRIGHT_JUNIT_OUTPUT_NAME=/app/test-results/results.xml
 
 # Execute tests with proper reporter configuration
+# Use the CI config if it exists, otherwise use the default config
+if [ -f "playwright.config.ci.ts" ]; then
+    echo "📝 Using CI-specific Playwright configuration"
+    CONFIG_ARG="--config playwright.config.ci.ts"
+else
+    echo "📝 Using default Playwright configuration"
+    CONFIG_ARG=""
+fi
+
 npx playwright test \
+    ${CONFIG_ARG} \
     --reporter=html,list,junit \
     --output=/app/artifacts \
     ${PLAYWRIGHT_ARGS} || TEST_EXIT_CODE=$?

--- a/apps/web/playwright.config.ci.ts
+++ b/apps/web/playwright.config.ci.ts
@@ -18,21 +18,21 @@ export default defineConfig({
 
   expect: {
     ...baseConfig.expect,
-    timeout: 10000, // 10 seconds for assertions in CI
+    timeout: 15000, // 15 seconds for assertions in CI (increased for Docker)
   },
 
   // More aggressive retries in CI
   retries: 3,
 
-  // Reduce workers to avoid resource contention
-  workers: 1,
+  // Use 2 workers for better parallelization while avoiding contention
+  workers: 2,
 
   // Force slower, more stable execution
   use: {
     ...baseConfig.use,
-    // Extended timeouts for CI
-    actionTimeout: 15000,
-    navigationTimeout: 30000,
+    // Extended timeouts for CI/Docker environment
+    actionTimeout: 20000, // Increased from 15000 for Docker stability
+    navigationTimeout: 45000, // Increased from 30000 for Docker environment
 
     // Always capture traces in CI for debugging
     trace: 'on',
@@ -45,7 +45,7 @@ export default defineConfig({
 
     // Add artificial delay between actions for stability
     launchOptions: {
-      slowMo: 100, // 100ms delay between actions
+      slowMo: 50, // Reduced from 100ms to balance speed and stability
     },
   },
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -74,9 +74,9 @@ services:
           'http://localhost:3001/api/v1/health',
         ]
       interval: 5s
-      timeout: 10s
-      retries: 30
-      start_period: 30s
+      timeout: 15s
+      retries: 40
+      start_period: 45s
     restart: unless-stopped
     # Remove volume mounts that break the standalone container
     # volumes:
@@ -106,9 +106,9 @@ services:
     healthcheck:
       test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:3000']
       interval: 5s
-      timeout: 10s
-      retries: 30
-      start_period: 60s
+      timeout: 15s
+      retries: 40
+      start_period: 90s
     restart: unless-stopped
     # Remove volume mounts that break the standalone container
     # volumes:
@@ -159,6 +159,7 @@ services:
       # Mount test files and config (read-only for consistency)
       - ./apps/web/e2e:/app/apps/web/e2e:ro
       - ./apps/web/playwright.config.ts:/app/apps/web/playwright.config.ts:ro
+      - ./apps/web/playwright.config.ci.ts:/app/apps/web/playwright.config.ci.ts:ro
       # Mount output directories (read-write for results)
       - ./playwright-report:/app/playwright-report:rw
       - ./test-results:/app/test-results:rw


### PR DESCRIPTION
## 概要

Docker環境でのE2Eテスト失敗を部分的に改善する修正を実施しました。

## 変更内容

### 1. Playwright CI設定の正しい読み込み
- `PLAYWRIGHT_ARGS`環境変数を使用してCI設定ファイルを指定
- `docker-compose.test.yml`にCI設定ファイルをマウント
- `Dockerfile.playwright`でCI設定の自動検出ロジックを追加

### 2. タイムアウト設定の調整
- **actionTimeout**: 15秒 → 20秒（Docker環境での安定性向上）
- **navigationTimeout**: 30秒 → 45秒（Docker環境での遅延を考慮）
- **expectTimeout**: 10秒 → 15秒（アサーションの余裕を追加）
- **slowMo**: 100ms → 50ms（速度と安定性のバランス改善）

### 3. ヘルスチェックの改善
- API/Webサービスのヘルスチェック待機時間を延長
- リトライ回数を30回から40回に増加
- start_periodを延長（API: 30秒→45秒、Web: 60秒→90秒）

### 4. ワーカー数の最適化
- CI環境でのワーカー数を1から2に増加（パフォーマンス改善）

## テスト結果

- ✅ ローカルでESLintチェック通過
- ✅ ローカルでTypeScriptチェック通過
- ✅ 通常のE2Eテスト通過
- ❌ Docker E2Eテストは依然として失敗（根本原因は別途対応）

## 今後の対応

Docker E2Eテストの根本的な問題は、Express.js APIサーバーとNext.jsの複雑な連携にあることが判明しました。
この問題は #272 で計画されているアーキテクチャ移行により解決予定です。

## 関連Issue

- Partially addresses #270
- 根本解決は #272 で対応予定

## チェックリスト

- [x] コードの品質チェックを実行
- [x] テストファイルのシンタックスを確認
- [x] 通常のE2Eテストが成功することを確認
- [ ] Docker E2Eテストの成功（根本解決は別途対応）