### PR TITLE
fix: Express API削除後の残作業対応 (#284)

### DIFF
--- a/Dockerfile.playwright
+++ b/Dockerfile.playwright
@@ -26,7 +26,6 @@ WORKDIR /app
 # Copy package files
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
 COPY apps/web/package.json ./apps/web/
-COPY apps/api/package.json ./apps/api/
 COPY packages/database/package.json ./packages/database/
 COPY packages/types/package.json ./packages/types/
 COPY packages/errors/package.json ./packages/errors/
@@ -135,26 +134,7 @@ if [ ! -z "$BASE_URL" ]; then
     fi
 fi
 
-# Wait for API service to be ready
-if [ ! -z "$API_URL" ]; then
-    echo "⏳ Waiting for API service at ${API_URL}..."
-    max_attempts=30
-    attempt=0
-    while [ $attempt -lt $max_attempts ]; do
-        if wget --spider --quiet --tries=1 --timeout=2 ${API_URL}/api/v1/health 2>/dev/null; then
-            echo "✅ API service is ready"
-            break
-        fi
-        echo "  Attempt $((attempt+1))/$max_attempts - API service not ready, waiting..."
-        sleep 2
-        attempt=$((attempt+1))
-    done
-    
-    if [ $attempt -eq $max_attempts ]; then
-        echo "❌ API service did not become ready in time"
-        exit 1
-    fi
-fi
+# API_URL check removed as Express API has been deleted
 
 # Run E2E tests
 echo "🎭 Running Playwright tests..."

--- a/apps/web/src/app/dashboard/settings/audit-logs/page.tsx
+++ b/apps/web/src/app/dashboard/settings/audit-logs/page.tsx
@@ -94,7 +94,7 @@ export default function AuditLogsPage() {
         params.append('endDate', new Date(endDate).toISOString());
       }
 
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/audit-logs?${params}`, {
+      const response = await fetch(`/api/audit-logs?${params}`, {
         headers: {
           Authorization: `Bearer ${localStorage.getItem('token')}`,
           'X-Organization-ID': currentOrganization?.id || '',
@@ -118,7 +118,7 @@ export default function AuditLogsPage() {
 
   const fetchEntityTypes = useCallback(async () => {
     try {
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/audit-logs/entity-types`, {
+      const response = await fetch(`/api/audit-logs/entity-types`, {
         headers: {
           Authorization: `Bearer ${localStorage.getItem('token')}`,
           'X-Organization-ID': currentOrganization?.id || '',
@@ -156,15 +156,12 @@ export default function AuditLogsPage() {
         params.append('endDate', new Date(endDate).toISOString());
       }
 
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/audit-logs/export?${params}`,
-        {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-            'X-Organization-ID': currentOrganization?.id || '',
-          },
-        }
-      );
+      const response = await fetch(`/api/audit-logs/export?${params}`, {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem('token')}`,
+          'X-Organization-ID': currentOrganization?.id || '',
+        },
+      });
 
       if (!response.ok) {
         throw new Error('Failed to export audit logs');

--- a/apps/web/src/lib/__tests__/api-client.test.ts
+++ b/apps/web/src/lib/__tests__/api-client.test.ts
@@ -198,7 +198,7 @@ describe('ApiClient - エラーハンドリングとローディング状態', (
       await apiClient.get('/accounts');
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:3001/api/v1/accounts',
+        '/api/accounts',
         expect.objectContaining({
           headers: expect.any(Headers),
         })
@@ -396,10 +396,7 @@ describe('ApiClient - エラーハンドリングとローディング状態', (
         success: true,
         message: 'インポートが完了しました',
       });
-      expect(xhrMock.open).toHaveBeenCalledWith(
-        'POST',
-        'http://localhost:3001/api/v1/accounts/import'
-      );
+      expect(xhrMock.open).toHaveBeenCalledWith('POST', '/api/accounts/import');
       expect(xhrMock.send).toHaveBeenCalledWith(expect.any(FormData));
     });
 


### PR DESCRIPTION
## 概要
PR #283 でExpress APIを削除した後に残っていた修正箇所に対応します。

## 変更内容

### 1. Dockerfile.playwright の修正
- `apps/api/package.json` への参照を削除
- API serviceの疎通確認処理を削除

### 2. api-client.test.ts のテスト修正
- モックURLを `http://localhost:3001/api/v1` から `/api` に更新
- fetchモックの調整でテストエラーを解消

### 3. audit-logs画面のAPI URL参照修正
- `process.env.NEXT_PUBLIC_API_URL` の直接参照を削除
- 相対パス `/api` を使用するように変更

## テスト結果
- ✅ api-client.test.ts: 全20テストがパス
- ✅ ESLintチェック: パス
- ✅ TypeScriptチェック: パス
- ✅ Unit Tests: パス

## 完了条件
- [x] すべてのCI/CDジョブが成功する
- [x] Dockerfile.playwrightが正常にビルドできる
- [x] api-client.test.tsのテストがすべてパスする
- [x] audit-logsページが正常に動作する
- [ ] E2E Dockerテストが実行できる

## 関連リンク
- 元のIssue: #284
- 前のPR: #283

🤖 Generated with Claude Code