### PR TITLE
fix: Jestテストにおける Date.now() のモック処理修正

### DIFF
--- a/apps/web/jest.setup.js
+++ b/apps/web/jest.setup.js
@@ -4,6 +4,25 @@ import '@testing-library/jest-dom';
 // This is required for react-hook-form with React 19
 global.IS_REACT_ACT_ENVIRONMENT = true;
 
+// Mock Date.now() to return a fixed timestamp for test stability
+// This ensures consistent test results across multiple runs
+// We use a counter to simulate time passing for tests that measure time differences
+const FIXED_TIMESTAMP = 1704067200000; // 2024-01-01 00:00:00 UTC
+let mockTimeOffset = 0;
+
+Date.now = jest.fn(() => {
+  // Return fixed timestamp plus offset to handle tests that measure time differences
+  // The offset increments by 100ms each call to simulate time passing
+  const currentTime = FIXED_TIMESTAMP + mockTimeOffset;
+  mockTimeOffset += 100; // Increment by 100ms for each call
+  return currentTime;
+});
+
+// Reset the time offset before each test to ensure test isolation
+beforeEach(() => {
+  mockTimeOffset = 0;
+});
+
 // Suppress JSDOM navigation warnings and React act warnings
 const originalError = console.error;
 beforeAll(() => {


### PR DESCRIPTION
## 概要

Date.now()のモック処理において、複数回の呼び出しに対して安定した結果を返すように修正しました。

## 問題

- Date.now()のモックが不安定で、テストの実行時に異なる値を返すことがある
- これにより、テスト結果が不安定になり、CI/CDでの信頼性が低下

## 解決策

- Date.now()を固定タイムスタンプ（2024-01-01 00:00:00 UTC）にモック
- 各呼び出しで100msずつインクリメントし、時間測定テストに対応
- beforeEachでオフセットをリセットし、テスト間の独立性を確保

## 変更内容

- `apps/web/jest.setup.js`: Date.now()のモック処理を追加

## テスト結果

```
✅ すべてのテストがパス
✅ モック処理の安定性確認済み
✅ ビルドが成功
```

## チェックリスト

- [x] コードがプロジェクトのスタイルガイドラインに従っている
- [x] セルフレビューを実施した
- [x] 既存のテストがすべて通過する
- [x] 必要な新しいテストを追加した（該当なし）
- [x] ドキュメントを更新した（該当なし）

## 関連Issue

Closes #300

🤖 Generated with [Claude Code](https://claude.ai/code)