### PR TITLE
fix: issue-analyzerの堅牢性向上とresolve-gh-issueの重複削除

### DIFF
--- a/.claude/agents/issue-analyzer.md
+++ b/.claude/agents/issue-analyzer.md
@@ -36,7 +36,14 @@ GitHub Issueを詳細に分析し、実装に必要な情報を構造化して�
 
 ## 実行フロー
 
-1. `gh issue view <issue-number> --repo knishioka/simple-bookkeeping` でIssue取得
+1. **Issue存在確認とタイプ判定**
+   - まず `gh issue view <issue-number> --repo knishioka/simple-bookkeeping --json number,title,state,body,labels` でIssue取得
+   - JSONレスポンスを確実に解析
+   - 以下のチェックを実施：
+     - レスポンスに`body`フィールドが存在することを確認（IssueにはbodyがあるがPRにはない場合がある）
+     - タイトルや本文に "wants to merge", "commits into", "pull request" などのPR特有の文言がないか確認
+   - 疑わしい場合は `gh pr view <issue-number>` も試行し、どちらが正しいか判定
+   - PRの場合は明確なエラーメッセージを返却
 2. Issue本文のパース
 3. 関連するコメントの分析
 4. TodoWriteで分析進捗を記録

--- a/.claude/commands/resolve-gh-issue.md
+++ b/.claude/commands/resolve-gh-issue.md
@@ -102,9 +102,6 @@ Claude Codeは、タスクの内容とサブエージェントの`description`�
   - 実装に必要な情報を抽出
 
   **注意**: `issue-analyzer`エージェントは`.claude/agents/issue-analyzer.md`に定義されています。Claude Codeが自動的に適切なタイミングで呼び出します。
-  - GitHub Issueの詳細を取得・分析
-  - 要件と受け入れ条件を構造化
-  - 実装に必要な情報を抽出
 
 - TodoWriteのステータスを「completed」に更新
 
@@ -165,15 +162,10 @@ Claude Codeは、タスクの内容とサブエージェントの`description`�
   - 現在の実装を理解するためコードベースを検索
   - 関連するファイル、モジュール、コンポーネントを特定
   - 既存のパターンと規約をレビュー
+  - ドキュメントと関連コードを分析
   - 変更の影響範囲を特定
 
   **注意**: `codebase-investigator`エージェントは`.claude/agents/codebase-investigator.md`に定義されています。
-
-- 現在の実装を理解するためコードベースを検索
-- 関連するファイル、モジュール、コンポーネントを特定
-- 既存のパターンと規約をレビュー
-- ドキュメントと関連コードを分析
-- 変更の影響範囲を特定
 
 ### 4. テスト駆動開発計画
 
@@ -230,18 +222,13 @@ Claude Codeは、タスクの内容とサブエージェントの`description`�
   - 既存のコードパターンと規約に従う（CLAUDE.mdを参照）
   - 変更を段階的に実装
   - 明確なメッセージでアトミックなコミットを作成
-  - TypeScriptの型安全性を維持
+  - コミットメッセージでIssue番号を参照
+  - 実装をシンプルに保ち、過度なエンジニアリングを避ける
+  - TypeScriptの型安全性を維持（any型の使用禁止）
+  - 共通型定義の使用（`@simple-bookkeeping/types`）
+  - エラークラスの使用（`@simple-bookkeeping/errors`）
 
   **注意**: `implementation`エージェントは`.claude/agents/implementation.md`に定義されています。
-
-- 既存のコードパターンと規約に従う（CLAUDE.mdを参照）
-- 変更を段階的に実装
-- 明確なメッセージでアトミックなコミットを作成
-- コミットメッセージでIssue番号を参照
-- 実装をシンプルに保ち、過度なエンジニアリングを避ける
-- TypeScriptの型安全性を維持（any型の使用禁止）
-- 共通型定義の使用（`@simple-bookkeeping/types`）
-- エラークラスの使用（`@simple-bookkeeping/errors`）
 
 #### 実装中の問題追跡【重要機能】
 


### PR DESCRIPTION
## 概要

resolve-gh-issueコマンドとissue-analyzerサブエージェントの堅牢性を向上させ、IssueとPRの混同を防ぐ改善を実施しました。

## 背景

Issue #300を処理する際に、IssueとPRを混同する可能性がある問題を発見しました。より確実なデータ取得と判定ロジックが必要でした。

## 改善内容

### issue-analyzerの改善
- GitHub CLIで`--json`フラグを使用してJSON形式で確実にデータ取得
- IssueとPRの判別ロジックを強化
- PR特有の文言チェックを追加（"wants to merge", "commits into"等）
- 疑わしい場合の追加検証処理

### resolve-gh-issueの改善
- サブエージェント呼び出し部分の重複コードを削除
  - issue-analyzer
  - codebase-investigator
  - implementation

## 効果

- Issue/PR判定の精度向上
- エラーハンドリングの強化
- コードの保守性向上
- 誤った番号を処理するリスクの軽減

## テスト

- [x] resolve-gh-issueコマンドのドキュメントが正しく更新されている
- [x] issue-analyzerの実行フローが改善されている
- [x] 重複コードが削除されている

🤖 Generated with [Claude Code](https://claude.ai/code)