### PR TITLE
fix: Docker E2Eテストの失敗を修正 - APIヘルスチェックの条件付き実行 (#324)

### DIFF
--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -136,10 +136,21 @@ async function performHealthCheck() {
   const webUrl = testEnv.webUrl;
   const apiUrl = testEnv.apiUrl;
 
-  const urls = [
-    { url: webUrl, name: 'Web' },
-    { url: `${apiUrl}/api/v1/health`, name: 'API' },
-  ];
+  // Build health check URLs based on environment
+  const urls = [{ url: webUrl, name: 'Web' }];
+
+  // Skip API health check in Docker environment or when using Server Actions
+  // The Express.js API has been deprecated and is not running in Docker
+  const skipApiHealthCheck =
+    testEnv.isDocker ||
+    process.env.SKIP_API_HEALTH_CHECK === 'true' ||
+    process.env.REUSE_SERVER === 'true';
+
+  if (!skipApiHealthCheck) {
+    urls.push({ url: `${apiUrl}/api/v1/health`, name: 'API' });
+  } else {
+    console.log('ℹ️ Skipping API health check (Docker environment or Server Actions mode)');
+  }
 
   // Add retry logic for CI environment
   const maxRetries = process.env.CI ? 5 : 1;


### PR DESCRIPTION
## 概要

Issue #324 を解決: Docker環境でのE2Eテスト失敗問題を修正

廃止予定のExpress.js APIサービスのヘルスチェックを環境に応じて条件付きでスキップするように修正しました。これにより、Docker E2Eテストが正常に実行されるようになります。

## 問題の背景

- Express.js APIサービスは廃止予定で、Docker環境では実行されていない
- `global-setup.ts`が常にAPIヘルスチェックを試みていたため、Docker E2Eテストが失敗
- Issue #317でタイムアウトを短縮した結果、この問題が顕在化

## 変更内容

### `apps/web/e2e/global-setup.ts`
- Docker環境検出時にAPIヘルスチェックをスキップ
- `SKIP_API_HEALTH_CHECK`環境変数による明示的なスキップをサポート
- `REUSE_SERVER`（Server Actionsモード）時もAPIヘルスチェックをスキップ
- スキップ時にわかりやすいログメッセージを出力

## テスト計画

- [x] ローカルでの動作確認（REUSE_SERVER=trueでスキップ動作を確認）
- [x] TypeScript型チェック通過
- [x] ESLintチェック通過
- [x] Unit Test通過
- [ ] Docker E2Eテスト通過（CI確認待ち）
- [ ] GitHub Actions CI全体の通過

## 関連

- Fixes #324
- Related to #317, #323

## レビューポイント

1. 条件付きロジックの妥当性（Docker、SKIP_API_HEALTH_CHECK、REUSE_SERVER）
2. 将来的なメンテナンス性（Express.js API完全削除後も問題ないか）
3. ログメッセージの適切性

🤖 Generated with [Claude Code](https://claude.ai/code)