### PR TITLE
fix: Next.js ビルドエラーを修正 - エラーページの dynamic export 削除 (#325)

### DIFF
--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -4,9 +4,6 @@ import { useEffect } from 'react';
 
 import { Button } from '@/components/ui/button';
 
-// Force dynamic rendering to avoid static generation error
-export const dynamic = 'force-dynamic';
-
 export default function Error({
   error,
   reset,

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -2,9 +2,6 @@
 
 import { useEffect } from 'react';
 
-// Force dynamic rendering to avoid static generation error
-export const dynamic = 'force-dynamic';
-
 export default function GlobalError({
   error,
   reset,
@@ -13,22 +10,25 @@ export default function GlobalError({
   reset: () => void;
 }) {
   useEffect(() => {
-    // Log the error to an error reporting service
     console.error('Global error:', error);
   }, [error]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <div className="text-center">
-        <h2 className="text-2xl font-bold text-gray-900 mb-4">システムエラーが発生しました</h2>
-        <p className="text-gray-600 mb-8">申し訳ございません。システムエラーが発生しました。</p>
-        <button
-          onClick={() => reset()}
-          className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
-        >
-          もう一度試す
-        </button>
-      </div>
-    </div>
+    <html lang="ja">
+      <body>
+        <div className="min-h-screen flex items-center justify-center bg-gray-50">
+          <div className="text-center">
+            <h2 className="text-2xl font-bold text-gray-900 mb-4">システムエラーが発生しました</h2>
+            <p className="text-gray-600 mb-8">申し訳ございません。システムエラーが発生しました。</p>
+            <button
+              onClick={() => reset()}
+              className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+            >
+              もう一度試す
+            </button>
+          </div>
+        </div>
+      </body>
+    </html>
   );
 }

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -2,9 +2,6 @@ import Link from 'next/link';
 
 import { Button } from '@/components/ui/button';
 
-// Force dynamic rendering to avoid static generation error
-export const dynamic = 'force-dynamic';
-
 export default function NotFound() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50">


### PR DESCRIPTION
## Summary

- App Routerのエラーページから`export const dynamic = 'force-dynamic'`を削除
- Next.js 15.5.2のビルドエラー「Html should not be imported outside of pages/_document」を修正
- global-error.tsxにhtml/bodyタグを追加してグローバルエラー処理を適切に実装

## Issue

Fixes #325

## Test plan

- [x] `pnpm build:web`でビルドが成功することを確認
- [x] `pnpm lint`でlintチェックがパスすることを確認
- [x] `pnpm typecheck`で型チェックがパスすることを確認
- [x] `pnpm test`でテストがパスすることを確認
- [ ] CIチェックがすべて通過することを確認

## Changes

- `apps/web/src/app/error.tsx`: dynamic exportを削除
- `apps/web/src/app/not-found.tsx`: dynamic exportを削除
- `apps/web/src/app/global-error.tsx`: dynamic exportを削除、html/bodyタグを追加

## 技術的詳細

Next.js 15.5.2のApp Routerでは、エラーページで`export const dynamic = 'force-dynamic'`を使用することはサポートされていません。これらのエクスポートを削除し、global-error.tsxには適切なhtml/bodyタグを追加しました。

🤖 Generated with [Claude Code](https://claude.ai/code)