### PR TITLE
feat: re-enable full E2E test suite execution (#326)

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   e2e-docker:
     runs-on: ubuntu-latest
-    timeout-minutes: 10 # Reduced from 30 minutes, but Docker needs more time than 5 minutes (Issue #317)
+    timeout-minutes: 20 # Increased to support full E2E test suite in Docker (Issue #326)
 
     steps:
       - name: Checkout code
@@ -106,7 +106,7 @@ jobs:
             -e DEBUG=${{ github.event.inputs.debug || 'false' }} \
             -e TEST_RETRIES=2 \
             -e TEST_WORKERS=2 \
-            -e PLAYWRIGHT_ARGS="--config playwright.config.ci.ts basic.spec.ts" \
+            -e PLAYWRIGHT_ARGS="--config playwright.config.ci.ts" \
             playwright || TEST_EXIT_CODE=$?
 
           # Export test exit code

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 5 # Reduced from 30 minutes to prevent CI resource waste (Issue #317)
+    timeout-minutes: 15 # Increased to support full E2E test suite (Issue #326)
 
     services:
       postgres:
@@ -107,10 +107,10 @@ jobs:
           TEST_VIEWER_EMAIL: ${{ secrets.TEST_VIEWER_EMAIL || 'viewer.test@localhost' }}
           TEST_VIEWER_PASSWORD: ${{ secrets.TEST_VIEWER_PASSWORD || 'ViewerTest123!' }}
         run: |
-          echo "[$(date '+%Y-%m-%d %H:%M:%S')] Starting E2E tests (basic.spec.ts only for smoke testing)"
+          echo "[$(date '+%Y-%m-%d %H:%M:%S')] Starting full E2E test suite"
           START_TIME=$(date +%s)
-          # Run only basic.spec.ts with timeout to prevent hanging
-          timeout 240 pnpm --filter @simple-bookkeeping/web exec playwright test basic.spec.ts --config playwright.config.ci.ts || TEST_EXIT=$?
+          # Run full test suite with reasonable timeout
+          timeout 840 pnpm --filter @simple-bookkeeping/web exec playwright test --config playwright.config.ci.ts || TEST_EXIT=$?
           END_TIME=$(date +%s)
           DURATION=$((END_TIME - START_TIME))
           echo "[$(date '+%Y-%m-%d %H:%M:%S')] E2E tests completed in ${DURATION} seconds with exit code ${TEST_EXIT:-0}"

--- a/apps/web/e2e/utils/performance-reporter.ts
+++ b/apps/web/e2e/utils/performance-reporter.ts
@@ -1,0 +1,145 @@
+import fs from 'fs';
+
+import type { Reporter, TestCase, TestResult, FullResult } from '@playwright/test/reporter';
+
+interface PerformanceData {
+  testName: string;
+  duration: number;
+  status: string;
+  retries: number;
+  timestamp: string;
+}
+
+/**
+ * Custom Playwright reporter for performance monitoring
+ * Issue #326: Full E2E test suite re-enablement with performance tracking
+ */
+export default class PerformanceReporter implements Reporter {
+  private performanceData: PerformanceData[] = [];
+  private startTime: number = 0;
+  private totalTests = 0;
+  private passedTests = 0;
+  private failedTests = 0;
+
+  onBegin() {
+    this.startTime = Date.now();
+    console.log('📊 Performance monitoring started');
+  }
+
+  onTestEnd(test: TestCase, result: TestResult) {
+    this.totalTests++;
+
+    if (result.status === 'passed') {
+      this.passedTests++;
+    } else if (result.status === 'failed') {
+      this.failedTests++;
+    }
+
+    const performanceEntry: PerformanceData = {
+      testName: test.title,
+      duration: result.duration,
+      status: result.status,
+      retries: result.retry,
+      timestamp: new Date().toISOString(),
+    };
+
+    this.performanceData.push(performanceEntry);
+
+    // Log slow tests (> 30 seconds)
+    if (result.duration > 30000) {
+      console.log(`⚠️  Slow test detected: ${test.title} (${Math.round(result.duration / 1000)}s)`);
+    }
+  }
+
+  onEnd(_result: FullResult) {
+    const totalDuration = Date.now() - this.startTime;
+    const avgTestDuration =
+      this.performanceData.length > 0
+        ? this.performanceData.reduce((sum, test) => sum + test.duration, 0) /
+          this.performanceData.length
+        : 0;
+
+    const slowestTest = this.performanceData.reduce(
+      (slowest, current) => (current.duration > slowest.duration ? current : slowest),
+      { testName: '', duration: 0, status: '', retries: 0, timestamp: '' }
+    );
+
+    // Performance summary
+    console.log('\n📈 Performance Summary:');
+    console.log(`  Total Duration: ${Math.round(totalDuration / 1000)}s`);
+    console.log(`  Tests: ${this.totalTests} (✅ ${this.passedTests}, ❌ ${this.failedTests})`);
+    console.log(`  Average Test Duration: ${Math.round(avgTestDuration / 1000)}s`);
+    console.log(
+      `  Slowest Test: ${slowestTest.testName} (${Math.round(slowestTest.duration / 1000)}s)`
+    );
+
+    // Save performance data to file
+    const performanceReport = {
+      summary: {
+        totalDuration,
+        totalTests: this.totalTests,
+        passedTests: this.passedTests,
+        failedTests: this.failedTests,
+        avgTestDuration,
+        slowestTest,
+        timestamp: new Date().toISOString(),
+      },
+      tests: this.performanceData,
+    };
+
+    try {
+      fs.writeFileSync(
+        'test-results/performance-report.json',
+        JSON.stringify(performanceReport, null, 2)
+      );
+      console.log('📁 Performance report saved to test-results/performance-report.json');
+    } catch (error) {
+      console.error('❌ Failed to save performance report:', error);
+    }
+
+    // GitHub Actions step summary
+    if (process.env.CI) {
+      try {
+        const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+        if (summaryFile) {
+          const summary = `## 🎭 E2E Test Performance Report
+
+### Summary
+- **Total Duration**: ${Math.round(totalDuration / 1000)}s
+- **Tests**: ${this.totalTests} total (✅ ${this.passedTests} passed, ❌ ${this.failedTests} failed)
+- **Average Test Duration**: ${Math.round(avgTestDuration / 1000)}s
+- **Slowest Test**: ${slowestTest.testName} (${Math.round(slowestTest.duration / 1000)}s)
+
+### Performance Insights
+${this.generatePerformanceInsights()}
+`;
+
+          fs.appendFileSync(summaryFile, summary);
+        }
+      } catch (error) {
+        console.error('❌ Failed to write GitHub step summary:', error);
+      }
+    }
+  }
+
+  private generatePerformanceInsights(): string {
+    const slowTests = this.performanceData.filter((test) => test.duration > 30000);
+    const retriedTests = this.performanceData.filter((test) => test.retries > 0);
+
+    let insights = '';
+
+    if (slowTests.length > 0) {
+      insights += `- 🐌 **${slowTests.length} slow tests** (>30s): Consider optimization\n`;
+    }
+
+    if (retriedTests.length > 0) {
+      insights += `- 🔄 **${retriedTests.length} tests** required retries: May indicate flaky tests\n`;
+    }
+
+    if (this.failedTests === 0 && slowTests.length === 0) {
+      insights += '- 🎉 **All tests passed** with good performance!\n';
+    }
+
+    return insights || '- No specific performance issues detected\n';
+  }
+}

--- a/apps/web/playwright.config.ci.ts
+++ b/apps/web/playwright.config.ci.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   ...baseConfig,
 
   // CI-specific timeout overrides for better stability
-  timeout: 45000, // Reduced from 60s to 45s for faster failure detection (Issue #317)
+  timeout: 60000, // Restored to 60s for full test suite stability (Issue #326)
 
   expect: {
     ...baseConfig.expect,
@@ -22,10 +22,10 @@ export default defineConfig({
   },
 
   // More aggressive retries in CI
-  retries: 2, // Reduced from 3 to 2 for faster feedback (Issue #317)
+  retries: 3, // Restored to 3 for better reliability with full suite (Issue #326)
 
-  // Use 2 workers for better parallelization while avoiding contention
-  workers: 2,
+  // Use 1 worker in CI to avoid resource contention
+  workers: process.env.CI ? 1 : 2,
 
   // Force slower, more stable execution
   use: {
@@ -55,5 +55,6 @@ export default defineConfig({
     ['json', { outputFile: 'test-results/results.json' }],
     ['junit', { outputFile: 'test-results/junit.xml' }],
     ['html', { outputFolder: 'test-results/html', open: 'never' }],
+    ['./e2e/utils/performance-reporter.ts'], // Issue #326: Performance tracking
   ],
 });


### PR DESCRIPTION
## Summary

This PR re-enables full E2E test suite execution that was temporarily reduced in Issue #317 to address CI resource constraints. The implementation provides a balanced approach with performance monitoring and maintains the ability to fall back to basic tests if needed.

## Changes

### GitHub Actions Workflows
- ✅ Increased CI timeout from 5 to 15 minutes for full test suite
- ✅ Increased Docker E2E timeout from 10 to 20 minutes  
- ✅ Removed `basic.spec.ts` restriction - now runs all E2E tests

### Playwright Configuration
- ✅ Restored timeouts to 60s for better stability with full suite
- ✅ Reduced CI workers to 1 to avoid resource contention
- ✅ Increased retries to 3 for better reliability

### Performance Monitoring
- ✅ Added custom performance reporter (`performance-reporter.ts`)
- ✅ Tracks test duration and identifies slow tests (>30s)
- ✅ Generates performance reports and GitHub Actions summaries
- ✅ Provides insights on test performance and reliability

## Test Plan

The changes have been validated locally with:
- [x] Lint checks pass
- [x] TypeScript compilation succeeds
- [x] Unit tests pass
- [x] Performance reporter integration verified

CI will validate:
- [ ] Full E2E test suite runs successfully
- [ ] Tests complete within 15-minute timeout
- [ ] Performance reports are generated
- [ ] No regression in test reliability

## Related Issues

- Closes #326
- References #317 (original timeout reduction)
- References #323 (PR that implemented temporary restriction)

## Rollout Strategy

The implementation supports gradual rollout:
1. **Phase 1**: Deploy with monitoring to observe performance
2. **Phase 2**: Optimize slow tests identified by performance reporter
3. **Phase 3**: Consider test sharding if execution time exceeds targets

## Backward Compatibility

- ✅ Maintains ability to run only basic tests via `test:e2e:basic` script
- ✅ No breaking changes to existing workflows
- ✅ Fallback mechanisms in place if full suite encounters issues

🤖 Generated with [Claude Code](https://claude.ai/code)