### PR TITLE
feat: Server Actions セキュリティ改善 Phase 1 - バリデーション基盤構築 (#348)

### DIFF
--- a/apps/web/src/app/actions/validation/accounts.ts
+++ b/apps/web/src/app/actions/validation/accounts.ts
@@ -1,0 +1,105 @@
+import { z } from 'zod';
+
+import { queryParamsSchema, uuidSchema } from './common';
+
+/**
+ * 勘定科目関連のバリデーションスキーマ
+ */
+
+// 勘定科目コードのバリデーション
+const accountCodeSchema = z
+  .string()
+  .min(1, { message: '勘定科目コードは必須です' })
+  .max(20, { message: '勘定科目コードは20文字以内で入力してください' })
+  .regex(/^[A-Z0-9_-]+$/i, {
+    message: '勘定科目コードは英数字、ハイフン、アンダースコアのみ使用できます',
+  });
+
+// 勘定科目名のバリデーション
+const accountNameSchema = z
+  .string()
+  .min(1, { message: '勘定科目名は必須です' })
+  .max(100, { message: '勘定科目名は100文字以内で入力してください' });
+
+// 勘定科目タイプのバリデーション
+const accountTypeSchema = z.enum(['ASSET', 'LIABILITY', 'EQUITY', 'REVENUE', 'EXPENSE']);
+
+// 勘定科目作成用スキーマ
+export const createAccountSchema = z.object({
+  code: accountCodeSchema,
+  name: accountNameSchema,
+  type: accountTypeSchema,
+  description: z.string().max(500).optional(),
+  parentId: uuidSchema.optional(),
+  isActive: z.boolean().optional().default(true),
+});
+
+// 勘定科目更新用スキーマ
+export const updateAccountSchema = z.object({
+  code: accountCodeSchema.optional(),
+  name: accountNameSchema.optional(),
+  type: accountTypeSchema.optional(),
+  description: z.string().max(500).optional(),
+  parentId: uuidSchema.nullable().optional(),
+  isActive: z.boolean().optional(),
+});
+
+// 勘定科目取得用パラメータスキーマ
+export const getAccountsParamsSchema = queryParamsSchema.extend({
+  type: accountTypeSchema.optional(),
+  isActive: z.boolean().optional(),
+  parentId: uuidSchema.nullable().optional(),
+});
+
+// 勘定科目取得用スキーマ
+export const getAccountSchema = z.object({
+  id: uuidSchema,
+});
+
+// 勘定科目削除用スキーマ
+export const deleteAccountSchema = z.object({
+  id: uuidSchema,
+  force: z.boolean().optional().default(false),
+});
+
+// 勘定科目インポート用スキーマ
+export const importAccountsSchema = z.object({
+  accounts: z
+    .array(
+      z.object({
+        code: accountCodeSchema,
+        name: accountNameSchema,
+        type: accountTypeSchema,
+        description: z.string().max(500).optional(),
+        parentCode: z.string().optional(),
+      })
+    )
+    .min(1, { message: 'インポートする勘定科目が必要です' })
+    .max(1000, { message: '一度にインポートできるのは1000件までです' }),
+  updateExisting: z.boolean().optional().default(false),
+});
+
+// 勘定科目集計用スキーマ
+export const accountBalanceParamsSchema = z.object({
+  accountId: uuidSchema,
+  startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  includeSubAccounts: z.boolean().optional().default(false),
+});
+
+// 勘定科目検索用スキーマ
+export const searchAccountsSchema = z.object({
+  query: z.string().min(1).max(100),
+  types: z.array(accountTypeSchema).optional(),
+  limit: z.number().int().min(1).max(100).optional().default(10),
+  includeInactive: z.boolean().optional().default(false),
+});
+
+// バリデーション関数のエクスポート
+export type CreateAccountInput = z.infer<typeof createAccountSchema>;
+export type UpdateAccountInput = z.infer<typeof updateAccountSchema>;
+export type GetAccountsParams = z.infer<typeof getAccountsParamsSchema>;
+export type DeleteAccountInput = z.infer<typeof deleteAccountSchema>;
+export type ImportAccountsInput = z.infer<typeof importAccountsSchema>;
+export type AccountBalanceParams = z.infer<typeof accountBalanceParamsSchema>;
+export type SearchAccountsInput = z.infer<typeof searchAccountsSchema>;

--- a/apps/web/src/app/actions/validation/common.ts
+++ b/apps/web/src/app/actions/validation/common.ts
@@ -1,0 +1,129 @@
+import { z } from 'zod';
+
+/**
+ * 共通バリデーションスキーマ
+ */
+
+// ページネーション用スキーマ
+export const paginationSchema = z.object({
+  page: z.number().int().min(1).optional().default(1),
+  pageSize: z.number().int().min(1).max(100).optional().default(20),
+});
+
+// クエリパラメータ用スキーマ
+export const queryParamsSchema = z.object({
+  page: z.number().int().min(1).optional(),
+  pageSize: z.number().int().min(1).max(100).optional(),
+  orderBy: z.string().optional(),
+  orderDirection: z.enum(['asc', 'desc']).optional(),
+  search: z.string().max(100).optional(),
+});
+
+// UUID形式のIDバリデーション
+export const uuidSchema = z.string().uuid({
+  message: '無効なID形式です',
+});
+
+// 日付文字列バリデーション (YYYY-MM-DD形式)
+export const dateStringSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, {
+    message: '日付はYYYY-MM-DD形式で入力してください',
+  })
+  .refine(
+    (date) => {
+      const d = new Date(date);
+      return !isNaN(d.getTime());
+    },
+    {
+      message: '有効な日付を入力してください',
+    }
+  );
+
+// 金額バリデーション
+export const amountSchema = z
+  .number()
+  .min(0, { message: '金額は0以上の値を入力してください' })
+  .max(999999999999, { message: '金額が大きすぎます' })
+  .refine(
+    (val) => {
+      // 小数点以下2桁まで許可
+      const decimals = (val.toString().split('.')[1] || '').length;
+      return decimals <= 2;
+    },
+    {
+      message: '金額は小数点以下2桁までです',
+    }
+  );
+
+// 組織IDバリデーション
+export const organizationIdSchema = z.string().uuid({
+  message: '無効な組織IDです',
+});
+
+// ユーザーIDバリデーション
+export const userIdSchema = z.string().uuid({
+  message: '無効なユーザーIDです',
+});
+
+// 検索文字列のサニタイズ
+export function sanitizeSearchString(search: string): string {
+  // SQLインジェクション対策: 特殊文字をエスケープ
+  return search
+    .replace(/[%_]/g, '\\$&') // SQL wildcards
+    .replace(/['";]/g, '') // Quotes and semicolons
+    .trim();
+}
+
+// 日付範囲バリデーション
+export const dateRangeSchema = z
+  .object({
+    startDate: dateStringSchema,
+    endDate: dateStringSchema,
+  })
+  .refine(
+    (data) => {
+      const start = new Date(data.startDate);
+      const end = new Date(data.endDate);
+      return start <= end;
+    },
+    {
+      message: '開始日は終了日以前である必要があります',
+      path: ['endDate'],
+    }
+  );
+
+/**
+ * Zodエラーをフォーマットしてユーザーフレンドリーなメッセージにする
+ * @param error - ZodError
+ * @returns フォーマットされたエラーメッセージ
+ */
+export function formatZodError(error: z.ZodError): string {
+  const issues = error.issues || [];
+  const errors = issues.map((err) => {
+    const path = err.path.join('.');
+    return path ? `${path}: ${err.message}` : err.message;
+  });
+
+  return errors.join(', ');
+}
+
+/**
+ * Zodエラーを詳細なエラー情報として返す
+ * @param error - ZodError
+ * @returns エラーの詳細情報
+ */
+export function getZodErrorDetails(error: z.ZodError): Record<string, string[]> {
+  const details: Record<string, string[]> = {};
+  const issues = error.issues || [];
+
+  issues.forEach((err) => {
+    const path = err.path.join('.') || 'general';
+    if (!details[path]) {
+      details[path] = [];
+    }
+    details[path].push(err.message);
+  });
+
+  return details;
+}

--- a/apps/web/src/app/actions/validation/journal-entries.ts
+++ b/apps/web/src/app/actions/validation/journal-entries.ts
@@ -1,0 +1,161 @@
+import { z } from 'zod';
+
+import { amountSchema, dateStringSchema, queryParamsSchema, uuidSchema } from './common';
+
+/**
+ * 仕訳エントリー関連のバリデーションスキーマ
+ */
+
+// 仕訳明細行のバリデーション
+const journalEntryLineSchema = z
+  .object({
+    accountId: uuidSchema,
+    debit: amountSchema.nullable().optional(),
+    credit: amountSchema.nullable().optional(),
+    description: z.string().max(500).optional(),
+    partnerId: uuidSchema.optional(),
+    projectId: uuidSchema.optional(),
+    tags: z.array(z.string()).optional(),
+  })
+  .refine(
+    (data) => {
+      // 借方か貸方のいずれか一方のみ入力されていることを確認
+      const hasDebit = data.debit !== null && data.debit !== undefined && data.debit > 0;
+      const hasCredit = data.credit !== null && data.credit !== undefined && data.credit > 0;
+      return (hasDebit && !hasCredit) || (!hasDebit && hasCredit);
+    },
+    {
+      message: '借方か貸方のいずれか一方のみ入力してください',
+    }
+  );
+
+// 仕訳エントリー作成用スキーマ
+export const createJournalEntrySchema = z
+  .object({
+    date: dateStringSchema,
+    description: z.string().min(1, { message: '摘要は必須です' }).max(500),
+    lines: z
+      .array(journalEntryLineSchema)
+      .min(2, { message: '仕訳には最低2行の明細が必要です' })
+      .max(100, { message: '仕訳明細は100行までです' }),
+    attachments: z.array(z.string().url()).optional(),
+    tags: z.array(z.string()).optional(),
+    memo: z.string().max(1000).optional(),
+    referenceNumber: z.string().max(50).optional(),
+  })
+  .refine(
+    (data) => {
+      // 借方と貸方の合計が一致することを確認
+      const totalDebit = data.lines.reduce((sum, line) => sum + (line.debit || 0), 0);
+      const totalCredit = data.lines.reduce((sum, line) => sum + (line.credit || 0), 0);
+      return Math.abs(totalDebit - totalCredit) < 0.01; // 浮動小数点誤差を考慮
+    },
+    {
+      message: '借方と貸方の合計金額が一致しません',
+    }
+  );
+
+// 仕訳エントリー更新用スキーマ
+export const updateJournalEntrySchema = z
+  .object({
+    date: dateStringSchema.optional(),
+    description: z.string().min(1).max(500).optional(),
+    lines: z.array(journalEntryLineSchema).min(2).max(100).optional(),
+    attachments: z.array(z.string().url()).optional(),
+    tags: z.array(z.string()).optional(),
+    memo: z.string().max(1000).optional(),
+    referenceNumber: z.string().max(50).optional(),
+  })
+  .refine(
+    (data) => {
+      if (!data.lines) return true;
+
+      // 借方と貸方の合計が一致することを確認
+      const totalDebit = data.lines.reduce((sum, line) => sum + (line.debit || 0), 0);
+      const totalCredit = data.lines.reduce((sum, line) => sum + (line.credit || 0), 0);
+      return Math.abs(totalDebit - totalCredit) < 0.01;
+    },
+    {
+      message: '借方と貸方の合計金額が一致しません',
+    }
+  );
+
+// 仕訳エントリー取得用パラメータスキーマ
+export const getJournalEntriesParamsSchema = queryParamsSchema
+  .extend({
+    startDate: dateStringSchema.optional(),
+    endDate: dateStringSchema.optional(),
+    accountId: uuidSchema.optional(),
+    partnerId: uuidSchema.optional(),
+    projectId: uuidSchema.optional(),
+    status: z.enum(['DRAFT', 'POSTED', 'CANCELLED']).optional(),
+    tags: z.array(z.string()).optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.startDate && data.endDate) {
+        const start = new Date(data.startDate);
+        const end = new Date(data.endDate);
+        return start <= end;
+      }
+      return true;
+    },
+    {
+      message: '開始日は終了日以前である必要があります',
+      path: ['endDate'],
+    }
+  );
+
+// 仕訳エントリー削除用スキーマ
+export const deleteJournalEntrySchema = z.object({
+  id: uuidSchema,
+  reason: z.string().min(1, { message: '削除理由は必須です' }).max(500),
+});
+
+// 仕訳エントリー承認用スキーマ
+export const approveJournalEntrySchema = z.object({
+  id: uuidSchema,
+  comment: z.string().max(500).optional(),
+});
+
+// 仕訳エントリー取消用スキーマ
+export const cancelJournalEntrySchema = z.object({
+  id: uuidSchema,
+  reason: z.string().min(1, { message: '取消理由は必須です' }).max(500),
+  reverseEntry: z.boolean().optional().default(false),
+});
+
+// 仕訳エントリー一括インポート用スキーマ
+export const importJournalEntriesSchema = z.object({
+  entries: z
+    .array(createJournalEntrySchema)
+    .min(1, { message: 'インポートする仕訳が必要です' })
+    .max(500, { message: '一度にインポートできるのは500件までです' }),
+  validateOnly: z.boolean().optional().default(false),
+  skipErrors: z.boolean().optional().default(false),
+});
+
+// 仕訳エントリー複製用スキーマ
+export const duplicateJournalEntrySchema = z.object({
+  id: uuidSchema,
+  newDate: dateStringSchema,
+  adjustDescription: z.boolean().optional().default(true),
+});
+
+// 仕訳エントリー検索用スキーマ
+export const searchJournalEntriesSchema = z.object({
+  query: z.string().min(1).max(100),
+  searchIn: z.array(z.enum(['description', 'memo', 'referenceNumber', 'tags'])).optional(),
+  limit: z.number().int().min(1).max(100).optional().default(20),
+});
+
+// 型定義のエクスポート
+export type CreateJournalEntryInput = z.infer<typeof createJournalEntrySchema>;
+export type UpdateJournalEntryInput = z.infer<typeof updateJournalEntrySchema>;
+export type GetJournalEntriesParams = z.infer<typeof getJournalEntriesParamsSchema>;
+export type DeleteJournalEntryInput = z.infer<typeof deleteJournalEntrySchema>;
+export type ApproveJournalEntryInput = z.infer<typeof approveJournalEntrySchema>;
+export type CancelJournalEntryInput = z.infer<typeof cancelJournalEntrySchema>;
+export type ImportJournalEntriesInput = z.infer<typeof importJournalEntriesSchema>;
+export type DuplicateJournalEntryInput = z.infer<typeof duplicateJournalEntrySchema>;
+export type SearchJournalEntriesInput = z.infer<typeof searchJournalEntriesSchema>;

--- a/apps/web/src/app/actions/validation/reports.ts
+++ b/apps/web/src/app/actions/validation/reports.ts
@@ -1,0 +1,197 @@
+import { z } from 'zod';
+
+import { dateStringSchema, uuidSchema } from './common';
+
+/**
+ * レポート関連のバリデーションスキーマ
+ */
+
+// レポートタイプのバリデーション
+const reportTypeSchema = z.enum([
+  'BALANCE_SHEET', // 貸借対照表
+  'INCOME_STATEMENT', // 損益計算書
+  'CASH_FLOW', // キャッシュフロー計算書
+  'TRIAL_BALANCE', // 試算表
+  'GENERAL_LEDGER', // 総勘定元帳
+  'JOURNAL_REPORT', // 仕訳帳
+  'ACCOUNT_LEDGER', // 勘定科目元帳
+  'AGING_REPORT', // 売掛金・買掛金年齢表
+  'TAX_REPORT', // 税務レポート
+  'CUSTOM', // カスタムレポート
+]);
+
+// レポート期間のバリデーション
+const reportPeriodSchema = z
+  .object({
+    startDate: dateStringSchema,
+    endDate: dateStringSchema,
+    comparePeriod: z
+      .object({
+        startDate: dateStringSchema,
+        endDate: dateStringSchema,
+      })
+      .optional(),
+  })
+  .refine(
+    (data) => {
+      const start = new Date(data.startDate);
+      const end = new Date(data.endDate);
+
+      if (start > end) {
+        return false;
+      }
+
+      if (data.comparePeriod) {
+        const compareStart = new Date(data.comparePeriod.startDate);
+        const compareEnd = new Date(data.comparePeriod.endDate);
+        if (compareStart > compareEnd) {
+          return false;
+        }
+      }
+
+      return true;
+    },
+    {
+      message: '開始日は終了日以前である必要があります',
+    }
+  );
+
+// レポート生成オプションのバリデーション
+const reportOptionsSchema = z.object({
+  includeZeroBalance: z.boolean().optional().default(false),
+  includeInactiveAccounts: z.boolean().optional().default(false),
+  groupByLevel: z.number().int().min(1).max(5).optional(),
+  showDetails: z.boolean().optional().default(true),
+  currency: z.string().optional().default('JPY'),
+  language: z.enum(['ja', 'en']).optional().default('ja'),
+  format: z.enum(['HTML', 'PDF', 'CSV', 'EXCEL']).optional().default('HTML'),
+});
+
+// 貸借対照表生成用スキーマ
+export const generateBalanceSheetSchema = z.object({
+  date: dateStringSchema,
+  compareDate: dateStringSchema.optional(),
+  options: reportOptionsSchema.optional(),
+});
+
+// 損益計算書生成用スキーマ
+export const generateIncomeStatementSchema = z.object({
+  period: reportPeriodSchema,
+  options: reportOptionsSchema.optional(),
+});
+
+// キャッシュフロー計算書生成用スキーマ
+export const generateCashFlowSchema = z.object({
+  period: reportPeriodSchema,
+  method: z.enum(['DIRECT', 'INDIRECT']).optional().default('INDIRECT'),
+  options: reportOptionsSchema.optional(),
+});
+
+// 試算表生成用スキーマ
+export const generateTrialBalanceSchema = z.object({
+  date: dateStringSchema,
+  includeAdjustments: z.boolean().optional().default(false),
+  options: reportOptionsSchema.optional(),
+});
+
+// 総勘定元帳生成用スキーマ
+export const generateGeneralLedgerSchema = z.object({
+  period: reportPeriodSchema,
+  accountIds: z.array(uuidSchema).optional(),
+  options: reportOptionsSchema.optional(),
+});
+
+// 仕訳帳生成用スキーマ
+export const generateJournalReportSchema = z.object({
+  period: reportPeriodSchema,
+  filters: z
+    .object({
+      accountId: uuidSchema.optional(),
+      partnerId: uuidSchema.optional(),
+      projectId: uuidSchema.optional(),
+      tags: z.array(z.string()).optional(),
+      status: z.enum(['DRAFT', 'POSTED', 'CANCELLED']).optional(),
+    })
+    .optional(),
+  options: reportOptionsSchema.optional(),
+});
+
+// 勘定科目元帳生成用スキーマ
+export const generateAccountLedgerSchema = z.object({
+  accountId: uuidSchema,
+  period: reportPeriodSchema,
+  includeSubAccounts: z.boolean().optional().default(false),
+  options: reportOptionsSchema.optional(),
+});
+
+// 売掛金・買掛金年齢表生成用スキーマ
+export const generateAgingReportSchema = z.object({
+  type: z.enum(['RECEIVABLE', 'PAYABLE']),
+  asOfDate: dateStringSchema,
+  agingBuckets: z.array(z.number().int().positive()).optional().default([30, 60, 90, 120]),
+  partnerId: uuidSchema.optional(),
+  options: reportOptionsSchema.optional(),
+});
+
+// 税務レポート生成用スキーマ
+export const generateTaxReportSchema = z.object({
+  period: reportPeriodSchema,
+  taxType: z.enum(['CONSUMPTION_TAX', 'CORPORATE_TAX', 'WITHHOLDING_TAX']),
+  includeDetails: z.boolean().optional().default(true),
+  options: reportOptionsSchema.optional(),
+});
+
+// カスタムレポート生成用スキーマ
+export const generateCustomReportSchema = z.object({
+  name: z.string().min(1).max(100),
+  period: reportPeriodSchema,
+  template: z.string().optional(),
+  parameters: z.record(z.string(), z.unknown()).optional(),
+  options: reportOptionsSchema.optional(),
+});
+
+// レポートスケジュール設定用スキーマ
+export const scheduleReportSchema = z.object({
+  reportType: reportTypeSchema,
+  schedule: z.object({
+    frequency: z.enum(['DAILY', 'WEEKLY', 'MONTHLY', 'QUARTERLY', 'YEARLY']),
+    dayOfWeek: z.number().int().min(0).max(6).optional(),
+    dayOfMonth: z.number().int().min(1).max(31).optional(),
+    time: z.string().regex(/^([01]\d|2[0-3]):([0-5]\d)$/),
+    timezone: z.string().optional().default('Asia/Tokyo'),
+  }),
+  recipients: z.array(z.string().email()).min(1),
+  reportConfig: z.record(z.string(), z.unknown()),
+  enabled: z.boolean().optional().default(true),
+});
+
+// レポートエクスポート用スキーマ
+export const exportReportSchema = z.object({
+  reportId: uuidSchema,
+  format: z.enum(['PDF', 'CSV', 'EXCEL', 'XML']),
+  includeAttachments: z.boolean().optional().default(false),
+  compress: z.boolean().optional().default(false),
+});
+
+// レポート履歴取得用スキーマ
+export const getReportHistorySchema = z.object({
+  reportType: reportTypeSchema.optional(),
+  startDate: dateStringSchema.optional(),
+  endDate: dateStringSchema.optional(),
+  limit: z.number().int().min(1).max(100).optional().default(20),
+});
+
+// 型定義のエクスポート
+export type GenerateBalanceSheetInput = z.infer<typeof generateBalanceSheetSchema>;
+export type GenerateIncomeStatementInput = z.infer<typeof generateIncomeStatementSchema>;
+export type GenerateCashFlowInput = z.infer<typeof generateCashFlowSchema>;
+export type GenerateTrialBalanceInput = z.infer<typeof generateTrialBalanceSchema>;
+export type GenerateGeneralLedgerInput = z.infer<typeof generateGeneralLedgerSchema>;
+export type GenerateJournalReportInput = z.infer<typeof generateJournalReportSchema>;
+export type GenerateAccountLedgerInput = z.infer<typeof generateAccountLedgerSchema>;
+export type GenerateAgingReportInput = z.infer<typeof generateAgingReportSchema>;
+export type GenerateTaxReportInput = z.infer<typeof generateTaxReportSchema>;
+export type GenerateCustomReportInput = z.infer<typeof generateCustomReportSchema>;
+export type ScheduleReportInput = z.infer<typeof scheduleReportSchema>;
+export type ExportReportInput = z.infer<typeof exportReportSchema>;
+export type GetReportHistoryInput = z.infer<typeof getReportHistorySchema>;


### PR DESCRIPTION
## 概要
GitHub Issue #348 の Phase 1 として、Server Actions のセキュリティ強化に必要なバリデーション基盤を構築しました。

## 関連Issue
Fixes #348 (Phase 1/3)

## 実装内容

### 📝 バリデーションスキーマの作成
新規ファイルを作成し、包括的な入力検証スキーマを実装：

#### `apps/web/src/app/actions/validation/common.ts`
- UUID、日付、金額の基本バリデーション
- SQLインジェクション対策用の検索文字列サニタイズ関数
- Zodエラーの日本語フォーマット関数
- エラー詳細情報の取得ヘルパー

#### `apps/web/src/app/actions/validation/accounts.ts`
- 勘定科目CRUD操作の完全なバリデーション
- 勘定科目コード形式の検証
- インポート/エクスポート用スキーマ

#### `apps/web/src/app/actions/validation/journal-entries.ts`
- 仕訳入力の複雑なバリデーション
- 借方・貸方バランスチェック
- 承認・取消用スキーマ

#### `apps/web/src/app/actions/validation/reports.ts`
- 各種レポート生成パラメータの検証
- 期間検証とオプション設定
- レポートスケジュール設定

### 🔧 types.ts の拡張
`apps/web/src/app/actions/types.ts` に以下を追加：
- `validateInput()`: 汎用バリデーション関数
- `formatZodError()`: エラーメッセージフォーマット
- `getZodErrorDetails()`: フィールド別エラー詳細

## 🔒 セキュリティ改善点

1. **SQLインジェクション対策**
   - 検索文字列の特殊文字エスケープ
   - 危険な文字の除去

2. **型安全性の向上**
   - Zodによる実行時型検証
   - TypeScript型推論との連携

3. **エラーメッセージの改善**
   - 日本語による詳細なエラー通知
   - フィールド別のエラー情報提供

## 🔧 技術的な修正

### Zod 4.0.14 互換性対応
- `z.record()` の引数を2つに修正（キーとバリューの型を明示）
- `error.issues` を使用（`error.errors` ではなく）
- `z.enum()` から不要な `errorMap` パラメータを削除

## ✅ テスト結果
- TypeScript型チェック: ✅ Pass
- ESLint: ✅ Pass
- Prettier: ✅ Pass
- Pre-commit hooks: ✅ Pass

## 📋 今後の作業（Phase 2, 3）

### Phase 2: Row Level Security (RLS)
- Supabase RLSポリシーの実装
- 組織別のデータアクセス制御
- ユーザー権限の詳細管理

### Phase 3: レート制限
- Server Actions へのレート制限実装
- Redis/Upstash を使用した制限管理
- API abuse 対策

### 統合作業
- 既存 Server Actions へのバリデーション統合
- エラーハンドリングの統一
- パフォーマンス最適化

## 📝 レビューポイント

1. バリデーションスキーマの網羅性
2. エラーメッセージの適切性
3. Zod 4.0.14 との互換性
4. 将来の統合に向けた設計

## 🚀 デプロイメント

このPRはバリデーション基盤のみの実装で、既存機能への影響はありません。
マージ後、Phase 2, 3 の実装を順次進めていきます。

🤖 Generated with [Claude Code](https://claude.ai/code)