### PR TITLE
fix: account-dialog component unit tests failing due to TextEncoder not defined (#350)

### DIFF
--- a/apps/web/jest.setup.js
+++ b/apps/web/jest.setup.js
@@ -1,8 +1,25 @@
 import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+
+// Add TextEncoder/TextDecoder polyfills for Node.js environment
+// Required for Next.js Server Actions which use these APIs
+if (typeof global.TextEncoder === 'undefined') {
+  global.TextEncoder = TextEncoder;
+}
+if (typeof global.TextDecoder === 'undefined') {
+  global.TextDecoder = TextDecoder;
+}
 
 // Configure React 19 testing environment for act() support
 // This is required for react-hook-form with React 19
 global.IS_REACT_ACT_ENVIRONMENT = true;
+
+// Mock Next.js cache module which is not available in test environment
+jest.mock('next/cache', () => ({
+  unstable_cache: jest.fn((fn) => fn),
+  revalidatePath: jest.fn(),
+  revalidateTag: jest.fn(),
+}));
 
 // Suppress JSDOM navigation warnings and React act warnings
 const originalError = console.error;


### PR DESCRIPTION
## Summary
Fixed 4 failing unit tests in the `account-dialog.test.tsx` file that were preventing CI from passing. The tests were failing due to missing Node.js polyfills and improper Server Actions mocking.

## Changes
- ✅ Added TextEncoder/TextDecoder polyfills to jest.setup.js for Node.js environment
- ✅ Mocked next/cache module which is required by Server Actions
- ✅ Fixed Server Actions mock setup using getter functions for proper hoisting
- ✅ Updated mock data structures to match actual database schema (snake_case fields)
- ✅ Ensured ESLint import order compliance

## Test Results
All 8 test scenarios now pass successfully:
- ✅ Scenario 1: Required field validation
- ✅ Scenario 2: Creating account with valid data
- ✅ Scenario 3: Creating account with parent selection
- ✅ Scenario 4: Editing existing account
- ✅ Scenario 5: Error handling for API failures
- ✅ Scenario 6: Character limit validation
- ✅ Scenario 7: Cancel button functionality
- ✅ Scenario 8: Parent account filtering by type

## Test Plan
- [x] Run unit tests locally: `pnpm test src/components/accounts/__tests__/account-dialog.test.tsx`
- [x] Verify no lint errors: `pnpm lint`
- [x] Verify TypeScript types: `pnpm typecheck`
- [ ] CI checks pass

## Related Issues
- Fixes #350

🤖 Generated with [Claude Code](https://claude.ai/code)