### PR TITLE
docs: Migrate and document test patterns from removed test pages (#413)

### DIFF
--- a/apps/web/src/app/(auth)/login/__tests__/user-story.test.tsx
+++ b/apps/web/src/app/(auth)/login/__tests__/user-story.test.tsx
@@ -1,0 +1,391 @@
+/**
+ * User Story Tests for Login Page
+ *
+ * NOTE: These are example test patterns migrated from the removed /login test page.
+ * Tests are marked as skip since they demonstrate patterns rather than
+ * testing actual implementation. Use these patterns as templates when
+ * writing real user story tests.
+ *
+ * These tests were migrated from the removed /login test page
+ * and adapted for the current authentication structure.
+ *
+ * User Story:
+ * As a user, I want to log into the system
+ * So that I can access my accounting data and perform bookkeeping tasks
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useRouter } from 'next/navigation';
+
+import { signIn } from '@/app/actions/auth';
+import LoginPage from '@/app/auth/login/page';
+
+// Mock Next.js navigation
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  redirect: jest.fn(),
+}));
+
+// Mock Server Actions
+jest.mock('@/app/actions/auth', () => ({
+  signIn: jest.fn(),
+}));
+
+describe.skip('Login Page - User Story Tests', () => {
+  const mockPush = jest.fn();
+  const mockRouter = {
+    push: mockPush,
+    back: jest.fn(),
+    forward: jest.fn(),
+    refresh: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useRouter as jest.Mock).mockReturnValue(mockRouter);
+  });
+
+  describe('User Journey: Successful Login', () => {
+    it('should allow a user to log in with valid credentials', async () => {
+      // Given: A user is on the login page
+      (signIn as jest.Mock).mockResolvedValue({
+        success: true,
+        data: { user: { id: 'user-123', email: 'user@example.com' } },
+      });
+
+      render(<LoginPage />);
+
+      // When: The user enters valid credentials
+      const emailInput = screen.getByLabelText(/メールアドレス|email/i);
+      const passwordInput = screen.getByLabelText(/パスワード|password/i);
+      const submitButton = screen.getByRole('button', { name: /ログイン|login/i });
+
+      await userEvent.type(emailInput, 'user@example.com');
+      await userEvent.type(passwordInput, 'SecurePassword123!');
+      await userEvent.click(submitButton);
+
+      // Then: The user should be logged in and redirected to dashboard
+      await waitFor(() => {
+        expect(signIn).toHaveBeenCalledWith(expect.any(FormData));
+      });
+
+      // Verify form data was sent correctly
+      const formDataCall = (signIn as jest.Mock).mock.calls[0][0];
+      expect(formDataCall.get('email')).toBe('user@example.com');
+      expect(formDataCall.get('password')).toBe('SecurePassword123!');
+
+      // Verify redirect to dashboard
+      expect(mockPush).toHaveBeenCalledWith('/dashboard');
+    });
+  });
+
+  describe('User Journey: Failed Login Attempts', () => {
+    it('should show error message for invalid credentials', async () => {
+      // Given: A user with invalid credentials
+      (signIn as jest.Mock).mockResolvedValue({
+        success: false,
+        error: 'メールアドレスまたはパスワードが正しくありません',
+      });
+
+      render(<LoginPage />);
+
+      // When: The user enters invalid credentials
+      const emailInput = screen.getByLabelText(/メールアドレス|email/i);
+      const passwordInput = screen.getByLabelText(/パスワード|password/i);
+      const submitButton = screen.getByRole('button', { name: /ログイン|login/i });
+
+      await userEvent.type(emailInput, 'wrong@example.com');
+      await userEvent.type(passwordInput, 'WrongPassword');
+      await userEvent.click(submitButton);
+
+      // Then: An error message should be displayed
+      await waitFor(() => {
+        expect(
+          screen.getByText(/メールアドレスまたはパスワードが正しくありません/)
+        ).toBeInTheDocument();
+      });
+
+      // And: The user should not be redirected
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it('should validate email format before submission', async () => {
+      // Given: A user on the login page
+      render(<LoginPage />);
+
+      // When: The user enters an invalid email format
+      const emailInput = screen.getByLabelText(/メールアドレス|email/i) as HTMLInputElement;
+      const passwordInput = screen.getByLabelText(/パスワード|password/i);
+      const submitButton = screen.getByRole('button', { name: /ログイン|login/i });
+
+      await userEvent.type(emailInput, 'not-an-email');
+      await userEvent.type(passwordInput, 'Password123!');
+
+      // Try to submit the form
+      await userEvent.click(submitButton);
+
+      // Then: The browser's built-in validation should prevent submission
+      expect(emailInput.validity.valid).toBe(false);
+      expect(signIn).not.toHaveBeenCalled();
+    });
+
+    it('should require both email and password fields', async () => {
+      // Given: A user on the login page
+      render(<LoginPage />);
+
+      // When: The user tries to submit without entering credentials
+      const submitButton = screen.getByRole('button', { name: /ログイン|login/i });
+      await userEvent.click(submitButton);
+
+      // Then: The form should not be submitted
+      expect(signIn).not.toHaveBeenCalled();
+
+      // And: Required field indicators should be visible
+      const emailInput = screen.getByLabelText(/メールアドレス|email/i) as HTMLInputElement;
+      const passwordInput = screen.getByLabelText(/パスワード|password/i) as HTMLInputElement;
+
+      expect(emailInput.required).toBe(true);
+      expect(passwordInput.required).toBe(true);
+    });
+  });
+
+  describe('User Journey: Form Interactions', () => {
+    it('should show loading state during login', async () => {
+      // Given: A slow server response
+      let resolveLogin: (value: any) => void;
+      (signIn as jest.Mock).mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveLogin = resolve;
+          })
+      );
+
+      render(<LoginPage />);
+
+      // When: The user submits the form
+      const emailInput = screen.getByLabelText(/メールアドレス|email/i);
+      const passwordInput = screen.getByLabelText(/パスワード|password/i);
+      const submitButton = screen.getByRole('button', { name: /ログイン|login/i });
+
+      await userEvent.type(emailInput, 'user@example.com');
+      await userEvent.type(passwordInput, 'Password123!');
+      await userEvent.click(submitButton);
+
+      // Then: A loading indicator should be shown
+      await waitFor(() => {
+        expect(screen.getByText(/ログイン中|logging in|処理中/i)).toBeInTheDocument();
+      });
+
+      // And: The submit button should be disabled
+      expect(submitButton).toBeDisabled();
+
+      // Complete the login
+      resolveLogin?.({ success: true });
+    });
+
+    it('should clear error messages when user starts typing', async () => {
+      // Given: A failed login attempt
+      (signIn as jest.Mock).mockResolvedValue({
+        success: false,
+        error: 'ログインに失敗しました',
+      });
+
+      render(<LoginPage />);
+
+      // Trigger an error
+      const emailInput = screen.getByLabelText(/メールアドレス|email/i);
+      const passwordInput = screen.getByLabelText(/パスワード|password/i);
+      const submitButton = screen.getByRole('button', { name: /ログイン|login/i });
+
+      await userEvent.type(emailInput, 'user@example.com');
+      await userEvent.type(passwordInput, 'wrong');
+      await userEvent.click(submitButton);
+
+      // Wait for error to appear
+      await waitFor(() => {
+        expect(screen.getByText(/ログインに失敗しました/)).toBeInTheDocument();
+      });
+
+      // When: The user starts typing again
+      await userEvent.type(emailInput, 'new');
+
+      // Then: The error message should be cleared
+      await waitFor(() => {
+        expect(screen.queryByText(/ログインに失敗しました/)).not.toBeInTheDocument();
+      });
+    });
+
+    it('should allow password visibility toggle', async () => {
+      // Given: A user on the login page
+      render(<LoginPage />);
+
+      const passwordInput = screen.getByLabelText(/パスワード|password/i) as HTMLInputElement;
+
+      // Initially password should be hidden
+      expect(passwordInput.type).toBe('password');
+
+      // When: The user clicks the visibility toggle (if it exists)
+      const toggleButton = screen.queryByRole('button', {
+        name: /パスワードを表示|show password/i,
+      });
+
+      if (toggleButton) {
+        await userEvent.click(toggleButton);
+
+        // Then: Password should be visible
+        expect(passwordInput.type).toBe('text');
+
+        // When: Clicked again
+        await userEvent.click(toggleButton);
+
+        // Then: Password should be hidden again
+        expect(passwordInput.type).toBe('password');
+      }
+    });
+  });
+
+  describe('User Journey: Navigation', () => {
+    it('should provide link to sign up page for new users', () => {
+      // Given: A new user on the login page
+      render(<LoginPage />);
+
+      // Then: There should be a link to the sign up page
+      const signUpLink = screen.getByRole('link', { name: /新規登録|sign up|アカウント作成/i });
+      expect(signUpLink).toBeInTheDocument();
+      expect(signUpLink).toHaveAttribute('href', expect.stringContaining('/signup'));
+    });
+
+    it('should provide password reset option', () => {
+      // Given: A user who forgot their password
+      render(<LoginPage />);
+
+      // Then: There should be a password reset link
+      const resetLink = screen.getByRole('link', { name: /パスワードを忘れた|forgot password/i });
+      expect(resetLink).toBeInTheDocument();
+      expect(resetLink).toHaveAttribute('href', expect.stringContaining('/reset-password'));
+    });
+  });
+
+  describe('User Journey: Accessibility', () => {
+    it('should be keyboard navigable', async () => {
+      // Given: A user using keyboard navigation
+      render(<LoginPage />);
+
+      const emailInput = screen.getByLabelText(/メールアドレス|email/i);
+      const passwordInput = screen.getByLabelText(/パスワード|password/i);
+      const submitButton = screen.getByRole('button', { name: /ログイン|login/i });
+
+      // When: The user tabs through the form
+      emailInput.focus();
+      expect(document.activeElement).toBe(emailInput);
+
+      await userEvent.tab();
+      expect(document.activeElement).toBe(passwordInput);
+
+      await userEvent.tab();
+      expect(document.activeElement).toBe(submitButton);
+    });
+
+    it('should announce errors to screen readers', async () => {
+      // Given: A user with a screen reader
+      (signIn as jest.Mock).mockResolvedValue({
+        success: false,
+        error: 'ログインに失敗しました',
+      });
+
+      render(<LoginPage />);
+
+      // When: An error occurs
+      const submitButton = screen.getByRole('button', { name: /ログイン|login/i });
+      await userEvent.click(submitButton);
+
+      // Then: The error should be in an aria-live region
+      await waitFor(() => {
+        const errorElement = screen.getByText(/ログインに失敗しました/);
+        const liveRegion = errorElement.closest('[aria-live]');
+        expect(liveRegion as Element).toHaveAttribute('aria-live', 'polite');
+      });
+    });
+
+    it('should have proper form labels', () => {
+      // Given: A user with assistive technology
+      render(<LoginPage />);
+
+      // Then: All form inputs should have associated labels
+      const emailInput = screen.getByLabelText(/メールアドレス|email/i);
+      const passwordInput = screen.getByLabelText(/パスワード|password/i);
+
+      expect(emailInput).toHaveAttribute('id');
+      expect(passwordInput).toHaveAttribute('id');
+
+      // Verify aria attributes if present
+      if (emailInput.getAttribute('aria-describedby')) {
+        const describedBy = emailInput.getAttribute('aria-describedby');
+        const description = describedBy ? document.getElementById(describedBy) : null;
+        expect(description).toBeInTheDocument();
+      }
+    });
+  });
+
+  describe('User Journey: Security Considerations', () => {
+    it('should not reveal whether email exists on failed login', async () => {
+      // Given: Different types of login failures
+      const testCases = [
+        {
+          email: 'nonexistent@example.com',
+          password: 'Password123!',
+          scenario: 'non-existent user',
+        },
+        { email: 'existing@example.com', password: 'WrongPassword', scenario: 'wrong password' },
+      ];
+
+      for (const testCase of testCases) {
+        jest.clearAllMocks();
+        (signIn as jest.Mock).mockResolvedValue({
+          success: false,
+          error: 'メールアドレスまたはパスワードが正しくありません',
+        });
+
+        render(<LoginPage />);
+
+        // When: Attempting to login
+        const emailInput = screen.getByLabelText(/メールアドレス|email/i);
+        const passwordInput = screen.getByLabelText(/パスワード|password/i);
+        const submitButton = screen.getByRole('button', { name: /ログイン|login/i });
+
+        await userEvent.type(emailInput, testCase.email);
+        await userEvent.type(passwordInput, testCase.password);
+        await userEvent.click(submitButton);
+
+        // Then: The same generic error message should be shown for both cases
+        await waitFor(() => {
+          expect(
+            screen.getByText(/メールアドレスまたはパスワードが正しくありません/)
+          ).toBeInTheDocument();
+        });
+      }
+    });
+
+    it('should handle rate limiting gracefully', async () => {
+      // Given: A rate-limited response
+      (signIn as jest.Mock).mockResolvedValue({
+        success: false,
+        error: 'ログイン試行回数が多すぎます。しばらくしてから再度お試しください。',
+      });
+
+      render(<LoginPage />);
+
+      // When: Attempting to login
+      const submitButton = screen.getByRole('button', { name: /ログイン|login/i });
+      await userEvent.click(submitButton);
+
+      // Then: A rate limiting message should be shown
+      await waitFor(() => {
+        expect(screen.getByText(/ログイン試行回数が多すぎます/)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/apps/web/src/app/actions/__tests__/integration/accounting-workflow.test.ts
+++ b/apps/web/src/app/actions/__tests__/integration/accounting-workflow.test.ts
@@ -1,0 +1,540 @@
+/**
+ * Accounting Workflow Integration Tests
+ *
+ * NOTE: These are example test patterns for documentation purposes.
+ * Tests are marked as skip since they demonstrate patterns rather than
+ * testing actual implementation. Use these patterns as templates when
+ * writing real integration tests.
+ *
+ * These tests verify complete accounting workflows including:
+ * - Account creation and management
+ * - Journal entry creation with validation
+ * - Report generation
+ * - Data consistency across operations
+ */
+
+import { createClient } from '@/lib/supabase/server';
+
+import { createAccount, deleteAccount, getAccounts } from '../../accounts';
+import { createJournalEntry, getJournalEntries } from '../../journal-entries';
+import { generateTrialBalance, generateBalanceSheet, generateIncomeStatement } from '../../reports';
+
+// Mock Supabase client
+jest.mock('@/lib/supabase/server');
+// Mock Next.js modules
+jest.mock('next/cache', () => ({
+  revalidatePath: jest.fn(),
+}));
+
+describe.skip('Accounting Workflow Integration', () => {
+  let mockSupabase: any;
+  const mockUserId = 'test-user-id';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Setup comprehensive Supabase mock
+    mockSupabase = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: { id: mockUserId } },
+          error: null,
+        }),
+      },
+      from: jest.fn(),
+    };
+    (createClient as jest.Mock).mockResolvedValue(mockSupabase);
+  });
+
+  // Helper function to create chainable query mock
+  const createQueryMock = (data: any, error: any = null) => {
+    return {
+      select: jest.fn().mockReturnThis(),
+      insert: jest.fn().mockReturnThis(),
+      update: jest.fn().mockReturnThis(),
+      delete: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      neq: jest.fn().mockReturnThis(),
+      in: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data, error }),
+      maybeSingle: jest.fn().mockResolvedValue({ data, error }),
+      then: jest.fn().mockResolvedValue({ data, error }),
+    };
+  };
+
+  describe.skip('Complete Bookkeeping Workflow', () => {
+    it('should complete a full double-entry bookkeeping cycle', async () => {
+      // Step 1: Create Chart of Accounts
+      const cashAccountData = {
+        id: 1,
+        code: '1010',
+        name: '現金',
+        account_type: 'asset',
+        user_id: mockUserId,
+        balance: 0,
+      };
+
+      const salesAccountData = {
+        id: 2,
+        code: '4010',
+        name: '売上高',
+        account_type: 'revenue',
+        user_id: mockUserId,
+        balance: 0,
+      };
+
+      const accountsReceivableData = {
+        id: 3,
+        code: '1210',
+        name: '売掛金',
+        account_type: 'asset',
+        user_id: mockUserId,
+        balance: 0,
+      };
+
+      // Mock account creation
+      mockSupabase.from
+        .mockReturnValueOnce(createQueryMock(cashAccountData)) // Cash account
+        .mockReturnValueOnce(createQueryMock(salesAccountData)) // Sales account
+        .mockReturnValueOnce(createQueryMock(accountsReceivableData)); // Accounts receivable
+
+      // Create accounts
+      const cashFormData = new FormData();
+      cashFormData.append('code', '1010');
+      cashFormData.append('name', '現金');
+      cashFormData.append('account_type', 'asset');
+
+      const cashResult = await createAccount(cashFormData);
+      expect(cashResult.success).toBe(true);
+      expect(cashResult.data).toEqual(cashAccountData);
+
+      const salesFormData = new FormData();
+      salesFormData.append('code', '4010');
+      salesFormData.append('name', '売上高');
+      salesFormData.append('account_type', 'revenue');
+
+      const salesResult = await createAccount(salesFormData);
+      expect(salesResult.success).toBe(true);
+
+      const receivableFormData = new FormData();
+      receivableFormData.append('code', '1210');
+      receivableFormData.append('name', '売掛金');
+      receivableFormData.append('account_type', 'asset');
+
+      const receivableResult = await createAccount(receivableFormData);
+      expect(receivableResult.success).toBe(true);
+
+      // Step 2: Create Journal Entry for Cash Sale
+      const cashSaleEntryData = {
+        id: 1,
+        date: '2024-01-15',
+        description: '現金売上',
+        user_id: mockUserId,
+        entries: [
+          {
+            id: 1,
+            journal_entry_id: 1,
+            account_id: 1,
+            debit: 100000,
+            credit: 0,
+          },
+          {
+            id: 2,
+            journal_entry_id: 1,
+            account_id: 2,
+            debit: 0,
+            credit: 100000,
+          },
+        ],
+      };
+
+      mockSupabase.from.mockReturnValueOnce(createQueryMock(cashSaleEntryData));
+
+      const cashSaleFormData = new FormData();
+      cashSaleFormData.append('date', '2024-01-15');
+      cashSaleFormData.append('description', '現金売上');
+      cashSaleFormData.append(
+        'entries',
+        JSON.stringify([
+          { account_id: 1, debit: 100000, credit: 0 },
+          { account_id: 2, debit: 0, credit: 100000 },
+        ])
+      );
+
+      const cashSaleResult = await createJournalEntry(cashSaleFormData);
+      expect(cashSaleResult.success).toBe(true);
+
+      // Verify debit equals credit
+      const totalDebit = cashSaleEntryData.entries.reduce((sum, e) => sum + e.debit, 0);
+      const totalCredit = cashSaleEntryData.entries.reduce((sum, e) => sum + e.credit, 0);
+      expect(totalDebit).toBe(totalCredit);
+
+      // Step 3: Create Journal Entry for Credit Sale
+      const creditSaleEntryData = {
+        id: 2,
+        date: '2024-01-20',
+        description: '掛売上',
+        user_id: mockUserId,
+        entries: [
+          {
+            id: 3,
+            journal_entry_id: 2,
+            account_id: 3,
+            debit: 50000,
+            credit: 0,
+          },
+          {
+            id: 4,
+            journal_entry_id: 2,
+            account_id: 2,
+            debit: 0,
+            credit: 50000,
+          },
+        ],
+      };
+
+      mockSupabase.from.mockReturnValueOnce(createQueryMock(creditSaleEntryData));
+
+      const creditSaleFormData = new FormData();
+      creditSaleFormData.append('date', '2024-01-20');
+      creditSaleFormData.append('description', '掛売上');
+      creditSaleFormData.append(
+        'entries',
+        JSON.stringify([
+          { account_id: 3, debit: 50000, credit: 0 },
+          { account_id: 2, debit: 0, credit: 50000 },
+        ])
+      );
+
+      const creditSaleResult = await createJournalEntry(creditSaleFormData);
+      expect(creditSaleResult.success).toBe(true);
+
+      // Step 4: Generate Trial Balance
+      const trialBalanceData = {
+        date: '2024-01-31',
+        accounts: [
+          {
+            code: '1010',
+            name: '現金',
+            debit_balance: 100000,
+            credit_balance: 0,
+          },
+          {
+            code: '1210',
+            name: '売掛金',
+            debit_balance: 50000,
+            credit_balance: 0,
+          },
+          {
+            code: '4010',
+            name: '売上高',
+            debit_balance: 0,
+            credit_balance: 150000,
+          },
+        ],
+        total_debit: 150000,
+        total_credit: 150000,
+      };
+
+      mockSupabase.from.mockReturnValueOnce(createQueryMock(trialBalanceData));
+
+      const trialBalanceResult = await generateTrialBalance('2024-01-31');
+      expect(trialBalanceResult.success).toBe(true);
+      expect(trialBalanceResult.data?.total_debit).toBe(trialBalanceResult.data?.total_credit);
+    });
+  });
+
+  describe.skip('Journal Entry Validation', () => {
+    it('should reject unbalanced journal entries', async () => {
+      // Arrange: Unbalanced entry
+      const formData = new FormData();
+      formData.append('date', '2024-01-15');
+      formData.append('description', 'Unbalanced Entry');
+      formData.append(
+        'entries',
+        JSON.stringify([
+          { account_id: 1, debit: 100000, credit: 0 },
+          { account_id: 2, debit: 0, credit: 50000 }, // Credit doesn't match debit
+        ])
+      );
+
+      // Act
+      const result = await createJournalEntry(formData);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('借方と貸方が一致しません');
+    });
+
+    it('should require at least two entries for a journal entry', async () => {
+      // Arrange: Single entry
+      const formData = new FormData();
+      formData.append('date', '2024-01-15');
+      formData.append('description', 'Single Entry');
+      formData.append('entries', JSON.stringify([{ account_id: 1, debit: 100000, credit: 0 }]));
+
+      // Act
+      const result = await createJournalEntry(formData);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('最低2つの仕訳明細が必要です');
+    });
+
+    it('should validate account exists before creating entry', async () => {
+      // Arrange: Non-existent account
+      mockSupabase.from.mockReturnValueOnce(
+        createQueryMock(null, { message: 'Account not found' })
+      );
+
+      const formData = new FormData();
+      formData.append('date', '2024-01-15');
+      formData.append('description', 'Invalid Account Entry');
+      formData.append(
+        'entries',
+        JSON.stringify([
+          { account_id: 9999, debit: 100000, credit: 0 },
+          { account_id: 2, debit: 0, credit: 100000 },
+        ])
+      );
+
+      // Act
+      const result = await createJournalEntry(formData);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Account not found');
+    });
+  });
+
+  describe.skip('Account Management', () => {
+    it('should prevent duplicate account codes', async () => {
+      // Arrange: First account creation succeeds
+      mockSupabase.from.mockReturnValueOnce(createQueryMock({ id: 1, code: '1010', name: 'Cash' }));
+
+      const firstFormData = new FormData();
+      firstFormData.append('code', '1010');
+      firstFormData.append('name', 'Cash');
+      firstFormData.append('account_type', 'asset');
+
+      const firstResult = await createAccount(firstFormData);
+      expect(firstResult.success).toBe(true);
+
+      // Arrange: Second account with same code fails
+      mockSupabase.from.mockReturnValueOnce(
+        createQueryMock(null, { message: 'Duplicate account code', code: '23505' })
+      );
+
+      const secondFormData = new FormData();
+      secondFormData.append('code', '1010');
+      secondFormData.append('name', 'Different Name');
+      secondFormData.append('account_type', 'asset');
+
+      // Act
+      const secondResult = await createAccount(secondFormData);
+
+      // Assert
+      expect(secondResult.success).toBe(false);
+      expect(secondResult.error).toContain('account code');
+    });
+
+    it('should update account balance after journal entries', async () => {
+      // Initial account with zero balance
+      const initialAccount = {
+        id: 1,
+        code: '1010',
+        name: '現金',
+        account_type: 'asset',
+        balance: 0,
+      };
+
+      // After journal entry, balance should be updated
+      const updatedAccount = {
+        ...initialAccount,
+        balance: 100000,
+      };
+
+      // Mock the sequence of operations
+      mockSupabase.from
+        .mockReturnValueOnce(createQueryMock(initialAccount)) // Get initial
+        .mockReturnValueOnce(createQueryMock({ id: 1 })) // Create entry
+        .mockReturnValueOnce(createQueryMock(updatedAccount)); // Get updated
+
+      // Create journal entry affecting the account
+      const formData = new FormData();
+      formData.append('date', '2024-01-15');
+      formData.append('description', 'Cash Receipt');
+      formData.append(
+        'entries',
+        JSON.stringify([
+          { account_id: 1, debit: 100000, credit: 0 },
+          { account_id: 2, debit: 0, credit: 100000 },
+        ])
+      );
+
+      const entryResult = await createJournalEntry(formData);
+      expect(entryResult.success).toBe(true);
+
+      // Verify balance was updated
+      const accountResult = await getAccounts();
+      expect(accountResult.data?.[0].balance).toBe(100000);
+    });
+
+    it('should cascade delete related journal entries when deleting account', async () => {
+      // This test would verify referential integrity
+      // In practice, this might be handled by database constraints
+
+      // Arrange: Account with related entries
+      mockSupabase.from.mockReturnValueOnce(
+        createQueryMock(null, { message: 'Cannot delete account with existing entries' })
+      );
+
+      // Act
+      const result = await deleteAccount(1);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Cannot delete account with existing entries');
+    });
+  });
+
+  describe.skip('Report Generation', () => {
+    it('should generate accurate balance sheet', async () => {
+      // Mock data for balance sheet
+      const balanceSheetData = {
+        date: '2024-01-31',
+        assets: {
+          current: [
+            { code: '1010', name: '現金', balance: 100000 },
+            { code: '1210', name: '売掛金', balance: 50000 },
+          ],
+          fixed: [],
+          total: 150000,
+        },
+        liabilities: {
+          current: [],
+          longTerm: [],
+          total: 0,
+        },
+        equity: {
+          capital: 0,
+          retainedEarnings: 150000,
+          total: 150000,
+        },
+        total: 150000,
+      };
+
+      mockSupabase.from.mockReturnValueOnce(createQueryMock(balanceSheetData));
+
+      // Act
+      const result = await generateBalanceSheet('2024-01-31');
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data?.assets.total).toBe(
+        result.data?.liabilities.total + result.data?.equity.total
+      );
+    });
+
+    it('should generate accurate income statement', async () => {
+      // Mock data for income statement
+      const incomeStatementData = {
+        period_start: '2024-01-01',
+        period_end: '2024-01-31',
+        revenue: {
+          items: [{ code: '4010', name: '売上高', amount: 150000 }],
+          total: 150000,
+        },
+        expenses: {
+          items: [
+            { code: '5010', name: '仕入高', amount: 80000 },
+            { code: '6010', name: '給与', amount: 30000 },
+          ],
+          total: 110000,
+        },
+        netIncome: 40000,
+      };
+
+      mockSupabase.from.mockReturnValueOnce(createQueryMock(incomeStatementData));
+
+      // Act
+      const result = await generateIncomeStatement('2024-01-01', '2024-01-31');
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data?.netIncome).toBe(result.data?.revenue.total - result.data?.expenses.total);
+    });
+  });
+
+  describe.skip('Error Recovery and Transaction Handling', () => {
+    it('should rollback partial journal entry on failure', async () => {
+      // Simulate a failure mid-transaction
+      mockSupabase.from
+        .mockReturnValueOnce(createQueryMock({ id: 1 })) // First entry succeeds
+        .mockReturnValueOnce(
+          createQueryMock(null, { message: 'Database error' }) // Second entry fails
+        );
+
+      const formData = new FormData();
+      formData.append('date', '2024-01-15');
+      formData.append('description', 'Failed Transaction');
+      formData.append(
+        'entries',
+        JSON.stringify([
+          { account_id: 1, debit: 100000, credit: 0 },
+          { account_id: 2, debit: 0, credit: 100000 },
+        ])
+      );
+
+      // Act
+      const result = await createJournalEntry(formData);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Database error');
+
+      // Verify no partial data was saved
+      mockSupabase.from.mockReturnValueOnce(createQueryMock([], null));
+      const entries = await getJournalEntries();
+      expect(entries.data).toHaveLength(0);
+    });
+
+    it('should handle concurrent journal entry creation', async () => {
+      // Simulate concurrent requests
+      const promises = [];
+
+      for (let i = 1; i <= 3; i++) {
+        mockSupabase.from.mockReturnValueOnce(
+          createQueryMock({
+            id: i,
+            date: '2024-01-15',
+            description: `Entry ${i}`,
+          })
+        );
+
+        const formData = new FormData();
+        formData.append('date', '2024-01-15');
+        formData.append('description', `Entry ${i}`);
+        formData.append(
+          'entries',
+          JSON.stringify([
+            { account_id: 1, debit: 10000 * i, credit: 0 },
+            { account_id: 2, debit: 0, credit: 10000 * i },
+          ])
+        );
+
+        promises.push(createJournalEntry(formData));
+      }
+
+      // Act
+      const results = await Promise.all(promises);
+
+      // Assert
+      results.forEach((result) => {
+        expect(result.success).toBe(true);
+      });
+    });
+  });
+});

--- a/apps/web/src/app/actions/__tests__/integration/auth-workflow.test.ts
+++ b/apps/web/src/app/actions/__tests__/integration/auth-workflow.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Authentication Workflow Integration Tests
+ *
+ * NOTE: These are example test patterns for documentation purposes.
+ * Tests are marked as skip since they demonstrate patterns rather than
+ * testing actual implementation. Use these patterns as templates when
+ * writing real integration tests.
+ *
+ * These tests verify the complete authentication flow including:
+ * - User registration
+ * - Login/logout
+ * - Session management
+ * - Protected route access
+ */
+
+import { createClient } from '@/lib/supabase/server';
+
+import { signIn, signOut, signUp, getCurrentUser } from '../../auth';
+
+// Mock Supabase client
+jest.mock('@/lib/supabase/server');
+// Mock Next.js modules
+jest.mock('next/navigation', () => ({
+  redirect: jest.fn(),
+}));
+
+jest.mock('next/cache', () => ({
+  revalidatePath: jest.fn(),
+}));
+
+describe.skip('Authentication Workflow Integration', () => {
+  let mockSupabase: any;
+  const mockUser = {
+    id: 'test-user-id',
+    email: 'test@example.com',
+    created_at: new Date().toISOString(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Setup Supabase mock with chainable methods
+    mockSupabase = {
+      auth: {
+        signUp: jest.fn(),
+        signInWithPassword: jest.fn(),
+        signOut: jest.fn(),
+        getUser: jest.fn(),
+        getSession: jest.fn(),
+      },
+    };
+    (createClient as jest.Mock).mockResolvedValue(mockSupabase);
+  });
+
+  describe('User Registration Flow', () => {
+    it('should successfully register a new user', async () => {
+      // Arrange
+      const formData = new FormData();
+      formData.append('email', 'newuser@example.com');
+      formData.append('password', 'SecurePass123!');
+
+      mockSupabase.auth.signUp.mockResolvedValue({
+        data: {
+          user: { ...mockUser, email: 'newuser@example.com' },
+          session: { access_token: 'token', refresh_token: 'refresh' },
+        },
+        error: null,
+      });
+
+      // Act
+      const result = await signUp(formData);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(mockSupabase.auth.signUp).toHaveBeenCalledWith({
+        email: 'newuser@example.com',
+        password: 'SecurePass123!',
+      });
+    });
+
+    it('should handle duplicate email registration', async () => {
+      // Arrange
+      const formData = new FormData();
+      formData.append('email', 'existing@example.com');
+      formData.append('password', 'SecurePass123!');
+
+      mockSupabase.auth.signUp.mockResolvedValue({
+        data: { user: null, session: null },
+        error: {
+          message: 'User already registered',
+          status: 400,
+        },
+      });
+
+      // Act
+      const result = await signUp(formData);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('already registered');
+    });
+
+    it('should validate password requirements', async () => {
+      // Arrange
+      const formData = new FormData();
+      formData.append('email', 'newuser@example.com');
+      formData.append('password', '123'); // Too weak
+
+      // Act
+      const result = await signUp(formData);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Password must be at least');
+      expect(mockSupabase.auth.signUp).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Login/Logout Flow', () => {
+    it('should successfully log in with valid credentials', async () => {
+      // Arrange
+      const formData = new FormData();
+      formData.append('email', 'test@example.com');
+      formData.append('password', 'SecurePass123!');
+
+      mockSupabase.auth.signInWithPassword.mockResolvedValue({
+        data: {
+          user: mockUser,
+          session: { access_token: 'token', refresh_token: 'refresh' },
+        },
+        error: null,
+      });
+
+      // Act
+      const result = await signIn(formData);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(mockSupabase.auth.signInWithPassword).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        password: 'SecurePass123!',
+      });
+    });
+
+    it('should handle invalid credentials', async () => {
+      // Arrange
+      const formData = new FormData();
+      formData.append('email', 'test@example.com');
+      formData.append('password', 'WrongPassword');
+
+      mockSupabase.auth.signInWithPassword.mockResolvedValue({
+        data: { user: null, session: null },
+        error: {
+          message: 'Invalid login credentials',
+          status: 400,
+        },
+      });
+
+      // Act
+      const result = await signIn(formData);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid login credentials');
+    });
+
+    it('should successfully log out', async () => {
+      // Arrange
+      mockSupabase.auth.signOut.mockResolvedValue({ error: null });
+
+      // Act
+      const result = await signOut();
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(mockSupabase.auth.signOut).toHaveBeenCalled();
+    });
+
+    it('should handle logout errors gracefully', async () => {
+      // Arrange
+      mockSupabase.auth.signOut.mockResolvedValue({
+        error: { message: 'Network error' },
+      });
+
+      // Act
+      const result = await signOut();
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Network error');
+    });
+  });
+
+  describe('Session Management', () => {
+    it('should retrieve current user when authenticated', async () => {
+      // Arrange
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: mockUser },
+        error: null,
+      });
+
+      // Act
+      const result = await getCurrentUser();
+
+      // Assert
+      expect(result).toEqual(mockUser);
+      expect(mockSupabase.auth.getUser).toHaveBeenCalled();
+    });
+
+    it('should return null when not authenticated', async () => {
+      // Arrange
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: null },
+        error: null,
+      });
+
+      // Act
+      const result = await getCurrentUser();
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('should handle session expiry', async () => {
+      // Arrange
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: null },
+        error: { message: 'Session expired', status: 401 },
+      });
+
+      // Act
+      const result = await getCurrentUser();
+
+      // Assert
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('Complete Authentication Workflow', () => {
+    it('should complete full authentication lifecycle', async () => {
+      // 1. Register new user
+      const signUpData = new FormData();
+      signUpData.append('email', 'lifecycle@example.com');
+      signUpData.append('password', 'SecurePass123!');
+
+      mockSupabase.auth.signUp.mockResolvedValue({
+        data: {
+          user: { ...mockUser, email: 'lifecycle@example.com' },
+          session: { access_token: 'token', refresh_token: 'refresh' },
+        },
+        error: null,
+      });
+
+      const signUpResult = await signUp(signUpData);
+      expect(signUpResult.success).toBe(true);
+
+      // 2. Verify user is logged in
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: { ...mockUser, email: 'lifecycle@example.com' } },
+        error: null,
+      });
+
+      const currentUser = await getCurrentUser();
+      expect(currentUser?.email).toBe('lifecycle@example.com');
+
+      // 3. Log out
+      mockSupabase.auth.signOut.mockResolvedValue({ error: null });
+
+      const signOutResult = await signOut();
+      expect(signOutResult.success).toBe(true);
+
+      // 4. Verify user is logged out
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: null },
+        error: null,
+      });
+
+      const loggedOutUser = await getCurrentUser();
+      expect(loggedOutUser).toBeNull();
+
+      // 5. Log back in
+      const signInData = new FormData();
+      signInData.append('email', 'lifecycle@example.com');
+      signInData.append('password', 'SecurePass123!');
+
+      mockSupabase.auth.signInWithPassword.mockResolvedValue({
+        data: {
+          user: { ...mockUser, email: 'lifecycle@example.com' },
+          session: { access_token: 'token', refresh_token: 'refresh' },
+        },
+        error: null,
+      });
+
+      const signInResult = await signIn(signInData);
+      expect(signInResult.success).toBe(true);
+    });
+  });
+
+  describe('Edge Cases and Error Scenarios', () => {
+    it('should handle network timeouts', async () => {
+      // Arrange
+      const formData = new FormData();
+      formData.append('email', 'test@example.com');
+      formData.append('password', 'SecurePass123!');
+
+      mockSupabase.auth.signInWithPassword.mockRejectedValue(new Error('Network timeout'));
+
+      // Act & Assert
+      await expect(signIn(formData)).rejects.toThrow('Network timeout');
+    });
+
+    it('should handle malformed email addresses', async () => {
+      // Arrange
+      const formData = new FormData();
+      formData.append('email', 'not-an-email');
+      formData.append('password', 'SecurePass123!');
+
+      // Act
+      const result = await signIn(formData);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('valid email');
+      expect(mockSupabase.auth.signInWithPassword).not.toHaveBeenCalled();
+    });
+
+    it('should handle concurrent login attempts', async () => {
+      // Arrange
+      const formData = new FormData();
+      formData.append('email', 'test@example.com');
+      formData.append('password', 'SecurePass123!');
+
+      mockSupabase.auth.signInWithPassword.mockResolvedValue({
+        data: {
+          user: mockUser,
+          session: { access_token: 'token', refresh_token: 'refresh' },
+        },
+        error: null,
+      });
+
+      // Act - Simulate concurrent login attempts
+      const results = await Promise.all([signIn(formData), signIn(formData), signIn(formData)]);
+
+      // Assert
+      results.forEach((result) => {
+        expect(result.success).toBe(true);
+      });
+      expect(mockSupabase.auth.signInWithPassword).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/docs/testing/server-actions-patterns.md
+++ b/docs/testing/server-actions-patterns.md
@@ -1,0 +1,732 @@
+# Server Actions テストパターンガイド
+
+このドキュメントは、Next.js Server Actionsのテストパターンとベストプラクティスをまとめたものです。
+
+## 目次
+
+1. [概要](#概要)
+2. [基本的なテストパターン](#基本的なテストパターン)
+3. [フォーム送信のテスト](#フォーム送信のテスト)
+4. [非同期データフェッチのテスト](#非同期データフェッチのテスト)
+5. [エラーハンドリングのテスト](#エラーハンドリングのテスト)
+6. [モック戦略](#モック戦略)
+7. [統合テスト](#統合テスト)
+8. [E2Eテスト](#e2eテスト)
+9. [ベストプラクティス](#ベストプラクティス)
+
+## 概要
+
+Server Actionsは、サーバーサイドで実行される非同期関数で、フォーム送信やデータ操作に使用されます。これらを適切にテストすることで、アプリケーションの信頼性と保守性が向上します。
+
+### テストレベル
+
+1. **Unit Tests**: 個々のServer Actionの動作を検証
+2. **Integration Tests**: Server Actionsと他のコンポーネントとの連携を検証
+3. **E2E Tests**: ユーザーフローの完全な動作を検証
+
+## 基本的なテストパターン
+
+### Server Action の基本構造
+
+```typescript
+// app/actions/example.ts
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import { revalidatePath } from 'next/cache';
+
+export async function exampleAction(formData: FormData) {
+  const supabase = await createClient();
+
+  // 認証チェック
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return { success: false, error: 'Unauthorized' };
+  }
+
+  // データ処理
+  const value = formData.get('value') as string;
+
+  // データベース操作
+  const { data, error } = await supabase
+    .from('table')
+    .insert({ value, user_id: user.id })
+    .select()
+    .single();
+
+  if (error) {
+    return { success: false, error: error.message };
+  }
+
+  // キャッシュ無効化
+  revalidatePath('/path');
+
+  return { success: true, data };
+}
+```
+
+### Unit Test パターン
+
+```typescript
+// app/actions/__tests__/example.test.ts
+import { exampleAction } from '../example';
+import { createClient } from '@/lib/supabase/server';
+
+jest.mock('@/lib/supabase/server');
+jest.mock('next/cache', () => ({
+  revalidatePath: jest.fn(),
+}));
+
+describe('exampleAction', () => {
+  let mockSupabase: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Supabase モックのセットアップ
+    mockSupabase = {
+      auth: {
+        getUser: jest.fn(),
+      },
+      from: jest.fn(),
+    };
+    (createClient as jest.Mock).mockResolvedValue(mockSupabase);
+  });
+
+  it('should successfully process valid data', async () => {
+    // Arrange
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: { id: 'user-123' } },
+    });
+
+    const mockInsertChain = {
+      insert: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: { id: 1, value: 'test', user_id: 'user-123' },
+        error: null,
+      }),
+    };
+
+    mockSupabase.from.mockReturnValue(mockInsertChain);
+
+    const formData = new FormData();
+    formData.append('value', 'test');
+
+    // Act
+    const result = await exampleAction(formData);
+
+    // Assert
+    expect(result).toEqual({
+      success: true,
+      data: { id: 1, value: 'test', user_id: 'user-123' },
+    });
+    expect(mockSupabase.from).toHaveBeenCalledWith('table');
+    expect(mockInsertChain.insert).toHaveBeenCalledWith({
+      value: 'test',
+      user_id: 'user-123',
+    });
+  });
+
+  it('should handle authentication failure', async () => {
+    // Arrange
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: null },
+    });
+
+    const formData = new FormData();
+    formData.append('value', 'test');
+
+    // Act
+    const result = await exampleAction(formData);
+
+    // Assert
+    expect(result).toEqual({
+      success: false,
+      error: 'Unauthorized',
+    });
+    expect(mockSupabase.from).not.toHaveBeenCalled();
+  });
+});
+```
+
+## フォーム送信のテスト
+
+### FormData の作成とテスト
+
+```typescript
+describe('Form submission', () => {
+  it('should handle complex form data', async () => {
+    const formData = new FormData();
+    formData.append('title', 'Test Title');
+    formData.append('description', 'Test Description');
+    formData.append('items[]', 'item1');
+    formData.append('items[]', 'item2');
+    formData.append('file', new File(['content'], 'test.txt'));
+
+    const result = await submitFormAction(formData);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate required fields', async () => {
+    const formData = new FormData();
+    // 必須フィールドを意図的に省略
+
+    const result = await submitFormAction(formData);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('required');
+  });
+});
+```
+
+### バリデーションテスト
+
+```typescript
+describe('Form validation', () => {
+  it('should validate email format', async () => {
+    const formData = new FormData();
+    formData.append('email', 'invalid-email');
+
+    const result = await updateEmailAction(formData);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid email format');
+  });
+
+  it('should sanitize input data', async () => {
+    const formData = new FormData();
+    formData.append('comment', '<script>alert("XSS")</script>');
+
+    const result = await submitCommentAction(formData);
+
+    // XSSが除去されていることを確認
+    expect(result.data?.comment).not.toContain('<script>');
+  });
+});
+```
+
+## 非同期データフェッチのテスト
+
+### データフェッチアクション
+
+```typescript
+// app/actions/data.ts
+'use server';
+
+export async function fetchUserData(userId: string) {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from('users')
+    .select('*, posts(*)')
+    .eq('id', userId)
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  return data;
+}
+```
+
+### 非同期テストパターン
+
+```typescript
+describe('fetchUserData', () => {
+  it('should fetch user with related posts', async () => {
+    const mockData = {
+      id: 'user-123',
+      name: 'Test User',
+      posts: [
+        { id: 1, title: 'Post 1' },
+        { id: 2, title: 'Post 2' },
+      ],
+    };
+
+    mockSupabase.from.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: mockData, error: null }),
+    });
+
+    const result = await fetchUserData('user-123');
+
+    expect(result).toEqual(mockData);
+    expect(result.posts).toHaveLength(2);
+  });
+
+  it('should handle concurrent requests', async () => {
+    const promises = Array.from({ length: 5 }, (_, i) => fetchUserData(`user-${i}`));
+
+    const results = await Promise.all(promises);
+
+    expect(results).toHaveLength(5);
+    results.forEach((result, i) => {
+      expect(result.id).toBe(`user-${i}`);
+    });
+  });
+});
+```
+
+## エラーハンドリングのテスト
+
+### エラーケースのテストパターン
+
+```typescript
+describe('Error handling', () => {
+  it('should handle database connection errors', async () => {
+    mockSupabase.from.mockImplementation(() => {
+      throw new Error('Database connection failed');
+    });
+
+    const formData = new FormData();
+    formData.append('data', 'test');
+
+    const result = await performDatabaseAction(formData);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('connection failed');
+  });
+
+  it('should handle timeout errors', async () => {
+    mockSupabase.from.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      single: jest
+        .fn()
+        .mockImplementation(
+          () => new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), 100))
+        ),
+    });
+
+    const result = await fetchWithTimeout('test-id');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Timeout');
+  });
+
+  it('should handle validation errors', async () => {
+    const formData = new FormData();
+    formData.append('amount', '-100'); // 負の値
+
+    const result = await processPayment(formData);
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toEqual({
+      amount: 'Amount must be positive',
+    });
+  });
+});
+```
+
+### リトライロジックのテスト
+
+```typescript
+describe('Retry logic', () => {
+  it('should retry on transient failures', async () => {
+    let attempts = 0;
+    mockSupabase.from.mockReturnValue({
+      insert: jest.fn().mockReturnThis(),
+      single: jest.fn().mockImplementation(() => {
+        attempts++;
+        if (attempts < 3) {
+          return Promise.reject(new Error('Transient error'));
+        }
+        return Promise.resolve({ data: { id: 1 }, error: null });
+      }),
+    });
+
+    const result = await actionWithRetry(new FormData());
+
+    expect(result.success).toBe(true);
+    expect(attempts).toBe(3);
+  });
+});
+```
+
+## モック戦略
+
+### チェーナブルメソッドのモック
+
+```typescript
+// test-helpers/supabase-mock.ts
+export function createMockSupabaseClient() {
+  const mockClient = {
+    auth: {
+      getUser: jest.fn(),
+      signIn: jest.fn(),
+      signOut: jest.fn(),
+    },
+    from: jest.fn(),
+  };
+
+  const createChainableMock = (finalResult: any) => {
+    const chain = {
+      select: jest.fn().mockReturnThis(),
+      insert: jest.fn().mockReturnThis(),
+      update: jest.fn().mockReturnThis(),
+      delete: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      neq: jest.fn().mockReturnThis(),
+      gt: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      lt: jest.fn().mockReturnThis(),
+      lte: jest.fn().mockReturnThis(),
+      like: jest.fn().mockReturnThis(),
+      ilike: jest.fn().mockReturnThis(),
+      in: jest.fn().mockReturnThis(),
+      contains: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue(finalResult),
+      maybeSingle: jest.fn().mockResolvedValue(finalResult),
+    };
+    return chain;
+  };
+
+  mockClient.from.mockImplementation(() => createChainableMock({ data: null, error: null }));
+
+  return mockClient;
+}
+```
+
+### テストデータビルダー
+
+```typescript
+// test-helpers/builders.ts
+export class TestDataBuilder {
+  static user(overrides = {}) {
+    return {
+      id: 'user-test-id',
+      email: 'test@example.com',
+      created_at: new Date().toISOString(),
+      ...overrides,
+    };
+  }
+
+  static account(overrides = {}) {
+    return {
+      id: 1,
+      name: 'Test Account',
+      code: '1000',
+      type: 'asset',
+      user_id: 'user-test-id',
+      ...overrides,
+    };
+  }
+
+  static journalEntry(overrides = {}) {
+    return {
+      id: 1,
+      date: new Date().toISOString(),
+      description: 'Test Entry',
+      entries: [
+        { account_id: 1, debit: 1000, credit: 0 },
+        { account_id: 2, debit: 0, credit: 1000 },
+      ],
+      ...overrides,
+    };
+  }
+}
+```
+
+## 統合テスト
+
+### 統合テストの構造
+
+```typescript
+// app/actions/__tests__/integration/workflow.test.ts
+import { createAccount, createJournalEntry, generateReport } from '../../index';
+import { createClient } from '@/lib/supabase/server';
+
+describe('Accounting workflow integration', () => {
+  let supabase: any;
+  let testUserId: string;
+
+  beforeAll(async () => {
+    // 実際のテスト用データベースを使用
+    supabase = await createClient();
+
+    // テストユーザーの作成
+    const {
+      data: { user },
+    } = await supabase.auth.signUp({
+      email: `test-${Date.now()}@example.com`,
+      password: 'testpassword123',
+    });
+
+    testUserId = user!.id;
+  });
+
+  afterAll(async () => {
+    // テストデータのクリーンアップ
+    await supabase.from('journal_entries').delete().eq('user_id', testUserId);
+    await supabase.from('accounts').delete().eq('user_id', testUserId);
+    await supabase.auth.admin.deleteUser(testUserId);
+  });
+
+  it('should complete full accounting workflow', async () => {
+    // 1. 勘定科目の作成
+    const cashAccount = await createAccount({
+      name: '現金',
+      code: '1010',
+      type: 'asset',
+    });
+    expect(cashAccount.success).toBe(true);
+
+    const salesAccount = await createAccount({
+      name: '売上高',
+      code: '4010',
+      type: 'revenue',
+    });
+    expect(salesAccount.success).toBe(true);
+
+    // 2. 仕訳の作成
+    const journalEntry = await createJournalEntry({
+      date: new Date().toISOString(),
+      description: '現金売上',
+      entries: [
+        { account_id: cashAccount.data.id, debit: 10000, credit: 0 },
+        { account_id: salesAccount.data.id, debit: 0, credit: 10000 },
+      ],
+    });
+    expect(journalEntry.success).toBe(true);
+
+    // 3. レポートの生成
+    const report = await generateReport({
+      type: 'trial_balance',
+      period: 'current_month',
+    });
+    expect(report.success).toBe(true);
+    expect(report.data.total_debit).toBe(10000);
+    expect(report.data.total_credit).toBe(10000);
+  });
+});
+```
+
+### データベーストランザクションのテスト
+
+```typescript
+describe('Database transactions', () => {
+  it('should rollback on error', async () => {
+    const invalidEntry = {
+      date: new Date().toISOString(),
+      description: 'Invalid Entry',
+      entries: [
+        { account_id: 999999, debit: 1000, credit: 0 }, // 存在しないアカウントID
+        { account_id: 1, debit: 0, credit: 1000 },
+      ],
+    };
+
+    const result = await createJournalEntry(invalidEntry);
+
+    expect(result.success).toBe(false);
+
+    // エントリーが作成されていないことを確認
+    const { data: entries } = await supabase
+      .from('journal_entries')
+      .select('*')
+      .eq('description', 'Invalid Entry');
+
+    expect(entries).toHaveLength(0);
+  });
+});
+```
+
+## E2Eテスト
+
+### Playwright を使用した E2E テスト
+
+```typescript
+// e2e/server-actions.spec.ts
+import { test, expect } from '@playwright/test';
+import { setupAuth } from './helpers/auth';
+
+test.describe('Server Actions E2E', () => {
+  test.beforeEach(async ({ page }) => {
+    // 認証のセットアップ
+    await setupAuth(page);
+  });
+
+  test('should submit form using server action', async ({ page }) => {
+    await page.goto('/accounts/new');
+
+    // フォームの入力
+    await page.fill('[name="name"]', '現金');
+    await page.fill('[name="code"]', '1010');
+    await page.selectOption('[name="type"]', 'asset');
+
+    // Server Action の実行を監視
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes('/accounts/new') && response.request().method() === 'POST'
+    );
+
+    // フォーム送信
+    await page.click('button[type="submit"]');
+
+    const response = await responsePromise;
+    expect(response.status()).toBe(303); // リダイレクト
+
+    // 成功メッセージの確認
+    await expect(page.locator('.toast-success')).toContainText('作成しました');
+
+    // データが保存されたことを確認
+    await page.goto('/accounts');
+    await expect(page.locator('text=現金')).toBeVisible();
+  });
+
+  test('should handle server action errors', async ({ page }) => {
+    await page.goto('/accounts/new');
+
+    // 重複するコードを入力
+    await page.fill('[name="code"]', '1000'); // 既存のコード
+    await page.fill('[name="name"]', 'Duplicate');
+
+    await page.click('button[type="submit"]');
+
+    // エラーメッセージの確認
+    await expect(page.locator('.field-error')).toContainText('このコードは既に使用されています');
+  });
+});
+```
+
+### Server Actions のモック (E2E)
+
+```typescript
+// e2e/helpers/mock-server-actions.ts
+import { Page } from '@playwright/test';
+
+export async function mockServerAction(
+  page: Page,
+  actionName: string,
+  mockImplementation: Function
+) {
+  await page.addInitScript(
+    (args) => {
+      const { actionName, mockImpl } = args;
+
+      // Next.js の Server Action をインターセプト
+      window.__NEXT_ACTION_MOCKS__ = window.__NEXT_ACTION_MOCKS__ || {};
+      window.__NEXT_ACTION_MOCKS__[actionName] = new Function('return ' + mockImpl)();
+
+      // オリジナルの fetch をラップ
+      const originalFetch = window.fetch;
+      window.fetch = async (url, options) => {
+        if (options?.headers?.['Next-Action'] === actionName) {
+          const formData = await new Response(options.body).formData();
+          const result = await window.__NEXT_ACTION_MOCKS__[actionName](formData);
+          return new Response(JSON.stringify(result), {
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return originalFetch(url, options);
+      };
+    },
+    { actionName, mockImpl: mockImplementation.toString() }
+  );
+}
+
+// 使用例
+test('should mock server action', async ({ page }) => {
+  await mockServerAction(page, 'submitForm', async (formData: FormData) => {
+    return { success: true, message: 'Mocked response' };
+  });
+
+  await page.goto('/form');
+  await page.click('button[type="submit"]');
+  await expect(page.locator('.message')).toContainText('Mocked response');
+});
+```
+
+## ベストプラクティス
+
+### 1. テストの構造化
+
+- **Arrange-Act-Assert (AAA) パターン**を使用
+- テストケースは独立して実行可能にする
+- 共通のセットアップは `beforeEach` で行う
+
+### 2. モックの使用
+
+- 外部依存関係は必ずモック化
+- モックは最小限に留める
+- 可能な限り実際のデータ構造を使用
+
+### 3. エラーハンドリング
+
+- すべてのエラーケースをテスト
+- エラーメッセージが適切であることを確認
+- リトライロジックがある場合はそれもテスト
+
+### 4. パフォーマンス
+
+- 非同期処理のタイムアウトを設定
+- 並行処理のテストを含める
+- データベースクエリの効率性を確認
+
+### 5. セキュリティ
+
+- 認証・認可のテストを必須とする
+- 入力値のサニタイゼーションを確認
+- XSS、SQLインジェクション対策をテスト
+
+### 6. 保守性
+
+- テストコードもプロダクションコードと同じ品質基準を適用
+- DRY原則に従い、テストヘルパーを活用
+- テストの意図が明確になるよう命名
+
+## トラブルシューティング
+
+### よくある問題と解決方法
+
+#### 1. "Cannot find module" エラー
+
+```typescript
+// jest.config.js
+module.exports = {
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '^@lib/(.*)$': '<rootDir>/src/lib/$1',
+  },
+};
+```
+
+#### 2. Async Server Components のテスト
+
+```typescript
+// React 18+ の async components をテストする際の注意
+import { render, waitFor } from '@testing-library/react'
+
+test('async server component', async () => {
+  const Component = await import('./AsyncComponent')
+  const { container } = render(<Component.default />)
+
+  await waitFor(() => {
+    expect(container.textContent).toContain('Loaded')
+  })
+})
+```
+
+#### 3. FormData のテストでの問題
+
+```typescript
+// Node.js 環境で FormData を使用する場合
+import { FormData } from 'formdata-node';
+
+global.FormData = FormData as any;
+```
+
+## 参考リンク
+
+- [Next.js Server Actions ドキュメント](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations)
+- [Jest 公式ドキュメント](https://jestjs.io/docs/getting-started)
+- [Playwright 公式ドキュメント](https://playwright.dev/docs/intro)
+- [Testing Library ドキュメント](https://testing-library.com/docs/)
+
+## まとめ
+
+Server Actions のテストは、アプリケーションの信頼性を確保する上で重要です。Unit Test、Integration Test、E2E Test を適切に組み合わせることで、包括的なテストカバレッジを実現できます。このガイドのパターンを参考に、プロジェクトに適したテスト戦略を構築してください。


### PR DESCRIPTION
## Summary

- Created comprehensive Server Actions test patterns documentation
- Migrated valuable test patterns from removed development test pages (PR #412)  
- Added example integration tests for auth and accounting workflows

## Changes

### Documentation
- Added `/docs/testing/server-actions-patterns.md` with detailed test patterns for:
  - Unit testing Server Actions
  - Form submission testing
  - Async data fetching tests
  - Error handling tests
  - Mock strategies
  - Integration testing patterns
  - E2E testing patterns
  - Best practices and troubleshooting

### Test Examples
- Added `auth-workflow.test.ts` - Authentication workflow integration test examples
- Added `accounting-workflow.test.ts` - Accounting workflow integration test examples
- Added `user-story.test.tsx` - User story tests migrated from removed login page

**Note**: All example tests are marked as `skip` since they demonstrate patterns rather than testing actual implementation.

## Context

This is a follow-up task from PR #412 which removed development test pages. This PR preserves the valuable test patterns and implementation examples that were removed, documenting them for future reference and use as templates.

## Test plan

- [x] All files created successfully
- [x] Lint passes
- [x] Unit tests pass (example tests marked as skip)
- [ ] CI passes

## Related Issues

- Resolves #413 
- Follow-up from #400, #412

🤖 Generated with [Claude Code](https://claude.ai/code)