### PR TITLE
fix: Remove references to deleted packages in Dockerfile.playwright (#427)

### DIFF
--- a/Dockerfile.playwright
+++ b/Dockerfile.playwright
@@ -27,10 +27,8 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
 COPY apps/web/package.json ./apps/web/
 COPY packages/database/package.json ./packages/database/
-COPY packages/types/package.json ./packages/types/
 COPY packages/shared/package.json ./packages/shared/
 COPY packages/test-utils/package.json ./packages/test-utils/
-COPY packages/core/package.json ./packages/core/
 COPY packages/config/package.json ./packages/config/
 
 # Install dependencies
@@ -48,7 +46,6 @@ RUN pnpm --filter @simple-bookkeeping/database prisma:generate
 
 # Build only necessary packages (needed for test helpers)
 RUN pnpm --filter @simple-bookkeeping/database build || true
-RUN pnpm --filter @simple-bookkeeping/types build || true
 RUN pnpm --filter @simple-bookkeeping/shared build || true
 RUN pnpm --filter @simple-bookkeeping/config build || true
 RUN pnpm --filter @simple-bookkeeping/test-utils build || true


### PR DESCRIPTION
## 概要
E2E Tests (Comprehensive) CIワークフローの失敗を修正します。

## 問題
Dockerビルド時に削除済みパッケージ（`packages/types`と`packages/core`）への参照が残っていたため、ビルドが失敗していました。

## 変更内容
`Dockerfile.playwright`から以下を削除:
- `packages/types/package.json`のCOPY命令
- `packages/core/package.json`のCOPY命令  
- 対応するビルドコマンド

## テスト
- [x] ローカルでDockerfileの構文を確認
- [ ] CIでE2E Tests (Comprehensive)が成功することを確認

## 関連Issue
Resolves #427

## チェックリスト
- [x] コードがプロジェクトのコーディング規約に従っている
- [x] 変更がビルドエラーを引き起こさない
- [ ] CIパイプラインが全て成功する