### PR TITLE
fix: Resolve Next.js 15.5.2 build error by adding NODE_ENV=production (#386)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev -p ${WEB_PORT:-3000}",
-    "build": "next build",
+    "build": "NODE_ENV=production next build",
     "start": "next start -p ${WEB_PORT:-3000}",
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "turbo run build",
     "build:packages": "turbo run build --filter='./packages/*'",
     "build:apps": "turbo run build --filter='./apps/*'",
-    "build:web": "NODE_ENV=production turbo run build --filter=@simple-bookkeeping/web",
+    "build:web": "turbo run build --filter=@simple-bookkeeping/web",
     "start": "turbo run start",
     "lint": "turbo run lint",
     "lint:strict": "turbo run lint && npx eslint 'apps/**/*.{ts,tsx}' 'packages/**/*.ts' --max-warnings 0",


### PR DESCRIPTION
## 概要

Next.js 15.5.2で発生していた`<Html> should not be imported outside of pages/_document`エラーを解決し、ビルドプロセスを正常化しました。

## 関連Issue

Closes #386

## 変更内容

### 主な変更

- [ ] `apps/web/package.json`のbuildスクリプトに`NODE_ENV=production`を追加
- [ ] `package.json`の`build:web`スクリプトから重複する`NODE_ENV=production`を削除

### 技術的詳細

**問題の根本原因:**
Next.js 15.5.2では、NODE_ENVが明示的に設定されていない場合、静的生成フェーズでReactコンテキストの使用に関連するビルドエラーが発生していました。

**解決策:**
1. **apps/web/package.json**: buildスクリプトを`"build": "NODE_ENV=production next build"`に変更
2. **package.json**: build:webスクリプトを`"build:web": "turbo run build --filter=@simple-bookkeeping/web"`に簡素化（重複排除）

この変更により、Next.js 15.5.2とReact 19での安定したビルドが可能になりました。

## テスト

### 自動テスト

- ✅ Build Test: ビルドが正常に完了することを確認
- ✅ Static Generation: 全23ページの静的生成が成功
- ✅ Bundle Analysis: 適切なChunk分割とサイズ最適化を確認

### 手動テスト手順

1. `pnpm build`を実行
2. ビルドログにエラーがないことを確認
3. 静的ページ生成が完了することを確認
4. バンドルサイズが適切であることを確認

## ビルド結果

```
✓ Compiled successfully in 3.0s
✓ Generating static pages (23/23)
Route (app)                                      Size  First Load JS
┌ ○ /                                          3.6 kB         122 kB
├ ○ /_not-found                                 125 B         102 kB
├ ○ /auth/login                               1.53 kB         143 kB
[...]
○  (Static)  prerendered as static content
```

## チェックリスト

- [x] コードは既存のスタイルガイドに従っている
- [x] セルフレビューを実施した
- [x] ビルドが成功することを確認した
- [x] 変更による破壊的変更はない
- [x] Next.js 15.5.2 + React 19での動作を確認
- [x] 依存関係の更新はない

## レビュー観点

- [ ] ビルド設定: NODE_ENV設定の妥当性
- [ ] パフォーマンス: ビルド時間とバンドルサイズ
- [ ] 互換性: Next.js 15.5.2とReact 19での動作
- [ ] 設定の簡素化: 重複する環境変数設定の排除

## 備考

- この修正により、Next.js 15.5.2での安定したビルドが可能になります
- 今後のNext.jsアップデートでこの問題が根本的に解決される可能性があります
- ビルド時間やバンドルサイズに変更はありません

## ラベル

- `bug` - ビルドエラーの修正
- `next.js` - Next.js関連の変更

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>