### PR TITLE
fix: Next.js開発サーバーの監視対象を最適化してE2Eテストのタイムアウトを防止

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -26,6 +26,30 @@ const nextConfig = {
     domains: [],
     formats: ['image/avif', 'image/webp'],
   },
+  // Webpack configuration to optimize file watching
+  webpack: (config, { dev, isServer }) => {
+    if (dev) {
+      // Exclude test files and E2E tests from file watching in dev mode
+      config.watchOptions = {
+        ignored: [
+          '**/node_modules/**',
+          '**/.next/**',
+          '**/e2e/**',
+          '**/*.spec.ts',
+          '**/*.spec.tsx',
+          '**/*.test.ts',
+          '**/*.test.tsx',
+          '**/playwright/**',
+          '**/playwright.config.ts',
+          '**/__tests__/**',
+          '**/coverage/**',
+          '**/test-results/**',
+          '**/.git/**',
+        ],
+      };
+    }
+    return config;
+  },
 };
 
 module.exports = withBundleAnalyzer(nextConfig);


### PR DESCRIPTION
## 概要
Next.js開発サーバーの監視対象を最適化し、E2Eテスト実行時の不要な再コンパイルによるタイムアウトを防止する修正です。

## 問題
開発サーバー実行中にE2Eテストを実行すると、テストファイルの変更を検知して不要な再コンパイルが発生し、テストがタイムアウトする可能性がありました。

## 解決策
`next.config.js`にwebpackの`watchOptions`設定を追加し、以下のファイル/ディレクトリを監視対象から除外：

- `**/e2e/**` - E2Eテストディレクトリ
- `**/*.spec.ts`, `**/*.spec.tsx` - Specテストファイル  
- `**/*.test.ts`, `**/*.test.tsx` - Unitテストファイル
- `**/playwright/**` - Playwright設定ディレクトリ
- `playwright.config.ts` - Playwright設定ファイル
- `**/__tests__/**` - テストディレクトリ
- `**/coverage/**` - カバレッジレポート
- `**/test-results/**` - テスト結果

## 効果
- 開発サーバー実行中のE2Eテストでタイムアウトが発生しにくくなります
- テストファイルの変更時に不要な再コンパイルが起きなくなります
- 開発効率の向上

## テスト方法
1. 開発サーバーを起動: `pnpm dev`
2. 別ターミナルでE2Eテスト実行: `pnpm test:e2e`
3. テストファイルを編集してもサーバーが再コンパイルしないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)