### PR TITLE
fix: improve E2E test mock authentication reliability (#514)

### DIFF
--- a/apps/web/e2e/helpers/supabase-auth.ts
+++ b/apps/web/e2e/helpers/supabase-auth.ts
@@ -513,6 +513,16 @@ export class SupabaseAuth {
           secure: false,
           sameSite: 'Lax',
         },
+        // Issue #514: Add mockAuth cookie for middleware detection
+        {
+          name: 'mockAuth',
+          value: 'true',
+          url: 'http://localhost:3000',
+          path: '/',
+          httpOnly: false,
+          secure: false,
+          sameSite: 'Lax' as const,
+        },
       ]);
     }
   }

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -167,9 +167,12 @@ export async function middleware(request: NextRequest) {
   // Skip authentication in test/development environment when Supabase is not configured
   // or when explicitly using mock authentication in CI
   // CRITICAL SECURITY: Only allow test mode in non-production environments
+  // Issue #514: Also check cookie for E2E_USE_MOCK_AUTH for better test reliability
+  const mockAuthCookie = request.cookies.get('mockAuth')?.value === 'true';
   const isTestMode =
     process.env.NODE_ENV !== 'production' &&
     (process.env.E2E_USE_MOCK_AUTH === 'true' || // Explicit CI mock auth flag
+      mockAuthCookie || // Cookie-based mock auth (for E2E tests)
       !process.env.NEXT_PUBLIC_SUPABASE_URL ||
       process.env.NEXT_PUBLIC_SUPABASE_URL === 'https://dummy.supabase.co' ||
       process.env.NEXT_PUBLIC_SUPABASE_URL === 'https://placeholder.supabase.co');

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -66,13 +66,14 @@ const getWebServerConfig = () => {
     return undefined;
   }
 
-  // Always use Playwright's native web server management in CI
-  // In local development, reuse existing server if running
+  // Always restart server for E2E tests to ensure environment variables are loaded
+  // This fixes Issue #514 where E2E_USE_MOCK_AUTH wasn't recognized by middleware
+  // when added to .env.local after server startup
   return {
     command: SERVER_CONFIG.COMMAND,
     port: PORTS.WEB,
     timeout: timeouts.webServer,
-    reuseExistingServer: !isCI(),
+    reuseExistingServer: false,
     stdout: (process.env[ENV_KEYS.DEBUG] === 'true' ? 'pipe' : 'ignore') as 'pipe' | 'ignore',
     stderr: 'pipe' as const,
     env: {


### PR DESCRIPTION
## Summary

Implements hybrid approach (Option 3) from Issue #514 to ensure E2E test mock authentication works reliably in both CI and local environments.

### Changes

1. **playwright.config.ts**: Set `reuseExistingServer: false`
   - Always restarts dev server with fresh environment variables
   - Ensures `E2E_USE_MOCK_AUTH` is loaded from `.env.local`

2. **middleware.ts**: Add cookie-based mock auth detection  
   - Checks `mockAuth` cookie as fallback to environment variable
   - Provides redundancy when env vars don't propagate to Edge Runtime

3. **supabase-auth.ts**: Add `mockAuth` cookie  
   - Sets cookie alongside localStorage for middleware detection
   - Ensures consistent auth bypass mechanism

### Root Cause

Middleware uses environment variables from server startup time. Adding `E2E_USE_MOCK_AUTH=true` to `.env.local` after server starts doesn't take effect without restart.

### Solution Strategy

- **Primary**: Environment variable check (works in CI)
- **Fallback**: Cookie check (ensures local E2E tests work)  
- **Reliability**: Server restart ensures fresh environment

### Security

✅ `mockAuth` cookie only accepted when `NODE_ENV !== 'production'`  
✅ Multi-layer protection prevents production exploitation  
✅ No changes to production authentication flow  

### Test Plan

- [ ] Verify CI E2E tests continue to pass
- [ ] Test local E2E execution with `pnpm test:e2e`
- [ ] Confirm dashboard pages load correctly in E2E tests
- [ ] Validate no security regression in production builds

### Related Issues

Closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)