### PR TITLE
fix: use serviceClient for organization creation during signup (#538)

### DIFF
--- a/apps/web/app/actions/__tests__/auth.test.ts
+++ b/apps/web/app/actions/__tests__/auth.test.ts
@@ -142,8 +142,9 @@ describe('Auth Server Actions', () => {
       };
 
       // Mock from() to return different queries for each table
-      mockSupabaseClient.from.mockReturnValueOnce(orgInsertQuery); // organizations table
+      // IMPORTANT: Organization creation now uses serviceClient, not regular client
       mockServiceSupabaseClient.from
+        .mockReturnValueOnce(orgInsertQuery) // organizations table (now using serviceClient)
         .mockReturnValueOnce(userInsertQuery) // users table
         .mockReturnValueOnce(userOrgInsertQuery); // user_organizations table
 
@@ -203,8 +204,9 @@ describe('Auth Server Actions', () => {
       };
 
       // Mock from() to return different queries for each table
-      mockSupabaseClient.from.mockReturnValueOnce(orgInsertQuery); // organizations table
+      // IMPORTANT: Organization creation now uses serviceClient, not regular client
       mockServiceSupabaseClient.from
+        .mockReturnValueOnce(orgInsertQuery) // organizations table (now using serviceClient)
         .mockReturnValueOnce(userInsertQuery) // users table
         .mockReturnValueOnce(userOrgInsertQuery); // user_organizations table
 
@@ -293,7 +295,7 @@ describe('Auth Server Actions', () => {
         error: null,
       });
 
-      // Organization creation fails
+      // Organization creation fails (now using serviceClient)
       const orgInsertQuery = {
         insert: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
@@ -303,7 +305,8 @@ describe('Auth Server Actions', () => {
         }),
       };
 
-      mockSupabaseClient.from.mockReturnValueOnce(orgInsertQuery);
+      // IMPORTANT: Organization creation now uses serviceClient, not regular client
+      mockServiceSupabaseClient.from.mockReturnValueOnce(orgInsertQuery);
 
       const result = await signUp(validInput);
 


### PR DESCRIPTION
## 概要

新規ユーザー登録時に「組織の作成に失敗しました」エラーが発生する問題を修正しました。

## 問題

本番環境で新規登録を行うと、組織作成に失敗し、ユーザー登録が完了できませんでした。

## 根本原因

`apps/web/app/actions/auth.ts` の `signUp` 関数で：
- 組織作成（L129-137）: 通常の `supabase` クライアントを使用
- ユーザー作成（L163+）: `serviceClient`（RLS bypass）を使用

この不整合により、新規ユーザーはまだ組織に所属していないため、RLSポリシーが組織の作成をブロックしていました。

## 修正内容

1. `serviceClient` の作成を組織作成の前に移動
2. 組織作成で `serviceClient` を使用してRLSをバイパス
3. セキュリティ上の理由を説明するコメントを追加

### 変更ファイル
- `apps/web/app/actions/auth.ts` - メインの修正
- `apps/web/app/actions/__tests__/auth.test.ts` - テストのモック更新

## セキュリティ

この変更は安全です：
1. 'use server' コンテキストでのみサーバーサイドで実行
2. DB操作前にSupabase Authでユーザー認証を検証
3. Service clientの使用は最小限で、初期登録セットアップのみに限定

## テスト

- ✅ 全ユニットテスト通過
- ✅ テストモックを正しく更新
- ✅ 型チェック通過
- ✅ Lint通過
- ✅ ビルド成功

## 検証計画

1. ローカルで新規登録フローを手動テスト
2. E2Eテストで新規登録を検証
3. 本番環境にデプロイ後、実際の新規登録を確認

## 関連Issue

Fixes #538

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)